### PR TITLE
feat: 서버단 주문 데이터 저장 로직 구현, 발행된 내역에서 로또 번호 엔티티 분리

### DIFF
--- a/src/main/kotlin/app/LottoApplication.kt
+++ b/src/main/kotlin/app/LottoApplication.kt
@@ -5,9 +5,9 @@ import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
-@SpringBootApplication(scanBasePackages = ["lotto", "purchase", "toss", "common"])
-@EntityScan(basePackages = ["lotto", "purchase"])
-@EnableJpaRepositories(basePackages = ["lotto", "purchase"])
+@SpringBootApplication(scanBasePackages = ["lotto", "purchase", "order","toss", "common"])
+@EntityScan(basePackages = ["lotto", "purchase", "order"])
+@EnableJpaRepositories(basePackages = ["lotto", "purchase", "order"])
 class LottoApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/lotto/LottoInitializer.kt
+++ b/src/main/kotlin/lotto/LottoInitializer.kt
@@ -1,0 +1,51 @@
+package lotto
+
+import lotto.domain.entity.LottoRoundInfo
+import lotto.domain.entity.LottoStatus
+import lotto.domain.repository.LottoRoundInfoRepository
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.CommandLineRunner
+import org.springframework.context.annotation.Profile
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.time.LocalDateTime
+
+@Component
+@Profile("local")
+class LottoInitializer : CommandLineRunner {
+    private val log = LoggerFactory.getLogger(LottoInitializer::class.java)
+
+    @Autowired
+    private lateinit var lottoRoundInfoRepository: LottoRoundInfoRepository
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
+
+    override fun run(vararg args: String?) {
+        log.info("Server Setting Start")
+        val time = LocalDateTime.now()
+
+        lottoRoundInfoRepository.save(
+            LottoRoundInfo(
+                status = LottoStatus.ONGOING,
+                startDate = time.minusDays(1),
+                endDate = time.plusYears(1),
+                drawDate = time.plusYears(2),
+                round = 1000L,
+                paymentDeadline = time.plusYears(1).plusHours(1)
+            )
+        )
+        val sqlFilePath = "script/lotto_combinations_batched.sql"
+        val sqlContent = Files.readString(Paths.get(sqlFilePath))
+        try {
+            jdbcTemplate.execute(sqlContent)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        log.info("${sqlContent.length} Lotto Data Inserted")
+        log.info("Server Setting Finished")
+    }
+}

--- a/src/main/kotlin/lotto/config/LottoWebConfig.kt
+++ b/src/main/kotlin/lotto/config/LottoWebConfig.kt
@@ -1,0 +1,25 @@
+package lotto.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+import org.springframework.web.filter.CorsFilter
+
+@Configuration
+class LottoWebConfig {
+
+    @Bean
+    fun corsFilter(): CorsFilter {
+        val config = CorsConfiguration()
+        config.allowedOrigins = listOf("http://localhost:3000")
+        config.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
+        config.allowedHeaders = listOf("*")
+        config.allowCredentials = true
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", config) // 모든 엔드포인트에 적용
+
+        return CorsFilter(source)
+    }
+}

--- a/src/main/kotlin/lotto/config/LottoWebConfig.kt
+++ b/src/main/kotlin/lotto/config/LottoWebConfig.kt
@@ -2,6 +2,7 @@ package lotto.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.Environment
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 import org.springframework.web.filter.CorsFilter
@@ -10,16 +11,15 @@ import org.springframework.web.filter.CorsFilter
 class LottoWebConfig {
 
     @Bean
-    fun corsFilter(): CorsFilter {
+    fun corsFilter(environment: Environment): CorsFilter {
         val config = CorsConfiguration()
-        config.allowedOrigins = listOf("http://localhost:3000")
+        config.allowedOrigins = listOf(environment.getProperty("cors.allowed-origins"))
         config.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
-        config.allowedHeaders = listOf("*")
+        config.allowedHeaders = listOf("Authorization", "Content-Type", "Accept")
         config.allowCredentials = true
 
         val source = UrlBasedCorsConfigurationSource()
         source.registerCorsConfiguration("/**", config) // 모든 엔드포인트에 적용
-
         return CorsFilter(source)
     }
 }

--- a/src/main/kotlin/lotto/config/Sampling.kt
+++ b/src/main/kotlin/lotto/config/Sampling.kt
@@ -1,9 +1,0 @@
-package lotto.config
-
-import org.springframework.stereotype.Indexed
-
-@Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.RUNTIME)
-@Indexed
-annotation class Sampling {
-}

--- a/src/main/kotlin/lotto/controller/LottoOrderDataHttpRequest.kt
+++ b/src/main/kotlin/lotto/controller/LottoOrderDataHttpRequest.kt
@@ -1,0 +1,6 @@
+package lotto.controller
+
+data class LottoOrderDataHttpRequest(
+    val number: LottoRequest
+){
+}

--- a/src/main/kotlin/lotto/controller/LottoOrderDataHttpResponse.kt
+++ b/src/main/kotlin/lotto/controller/LottoOrderDataHttpResponse.kt
@@ -1,0 +1,17 @@
+package lotto.controller
+
+import lotto.service.dto.LottoOrderData
+
+data class LottoOrderDataHttpResponse(
+    val lottoPublishId: Long,
+    val orderId: String
+) {
+    companion object {
+        fun from(lottoOrderData: LottoOrderData): LottoOrderDataHttpResponse {
+            return LottoOrderDataHttpResponse(
+                lottoPublishId = lottoOrderData.lottoPublishId,
+                orderId = lottoOrderData.orderData.orderId
+            )
+        }
+    }
+}

--- a/src/main/kotlin/lotto/controller/LottoPurchaseController.kt
+++ b/src/main/kotlin/lotto/controller/LottoPurchaseController.kt
@@ -39,7 +39,7 @@ class LottoPurchaseController(
         )
     }
 
-    @Post("/api/order")
+    @Post("/api/orders")
     fun saveOrder(
         @Body lottoRequest: LottoRequest
     ): ApiResponse<LottoOrderDataHttpResponse> {

--- a/src/main/kotlin/lotto/controller/LottoPurchaseController.kt
+++ b/src/main/kotlin/lotto/controller/LottoPurchaseController.kt
@@ -4,11 +4,13 @@ import common.dto.ApiResponse
 import common.web.Body
 import common.web.HttpController
 import common.web.Post
+import lotto.service.LottoOrderService
 import lotto.service.LottoPurchaseService
 
 @HttpController
-class LottoController(
+class LottoPurchaseController(
     private val lottoPurchaseService: LottoPurchaseService,
+    private val lottoOrderService: LottoOrderService
 ) {
     @Post("/api/tickets")
     fun purchase(
@@ -17,7 +19,7 @@ class LottoController(
         val lottoPurchaseData =
             lottoPurchaseService.purchase(
                 lottoPurchaseHttpRequest.toPurchaseRequest(),
-                lottoPurchaseHttpRequest.toLottoNumbers()
+                lottoPurchaseHttpRequest.lottoPublishId
             )
         return ApiResponse.ok(
             data = LottoPurchaseHttpResponse.from(lottoPurchaseData)
@@ -34,6 +36,16 @@ class LottoController(
             )
         return ApiResponse.ok(
             data = LottoPurchaseHttpResponse.from(lottoPurchaseData)
+        )
+    }
+
+    @Post("/api/order")
+    fun saveOrder(
+        @Body lottoRequest: LottoRequest
+    ): ApiResponse<LottoOrderDataHttpResponse> {
+        val lottoOrderData = lottoOrderService.saveLottoOrder(lottoRequest.toLottoNumbers())
+        return ApiResponse.ok(
+            data = LottoOrderDataHttpResponse.from(lottoOrderData)
         )
     }
 }

--- a/src/main/kotlin/lotto/controller/LottoPurchaseHttpRequest.kt
+++ b/src/main/kotlin/lotto/controller/LottoPurchaseHttpRequest.kt
@@ -9,12 +9,8 @@ import java.math.BigDecimal
 
 data class LottoPurchaseHttpRequest @JsonCreator constructor(
     val purchaseHttpRequest: PurchaseHttpRequest,
-    val lottoRequest: LottoRequest
+    val lottoPublishId: Long
 ) {
-    fun toLottoNumbers(): LottoNumbers {
-        return LottoNumbers(lottoRequest.numbers)
-    }
-
     fun toPurchaseRequest(): LottoPurchaseRequest {
         return LottoPurchaseRequest(
             purchaseType = purchaseHttpRequest.purchaseType,
@@ -26,9 +22,13 @@ data class LottoPurchaseHttpRequest @JsonCreator constructor(
     }
 }
 
-data class LottoRequest(
-    val numbers: List<List<Int>>,
-)
+data class LottoRequest @JsonCreator constructor(
+    val numbers: List<List<Int>>
+) {
+    fun toLottoNumbers(): LottoNumbers {
+        return LottoNumbers(numbers)
+    }
+}
 
 data class PurchaseHttpRequest(
     val purchaseType: PurchaseType,

--- a/src/main/kotlin/lotto/domain/converter/EnumToStringConverter.kt
+++ b/src/main/kotlin/lotto/domain/converter/EnumToStringConverter.kt
@@ -1,0 +1,20 @@
+package lotto.domain.converter
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter
+abstract class EnumToStringConverter<T : Enum<T>>(
+    private val enumClass: Class<T>,
+) : AttributeConverter<T, String> {
+    override fun convertToDatabaseColumn(attribute: T?): String {
+        return attribute?.name ?: ""
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): T {
+        return java.lang.Enum.valueOf(
+            enumClass,
+            dbData?.trim() ?: throw IllegalArgumentException("Not Exist Enum $dbData")
+        )
+    }
+}

--- a/src/main/kotlin/lotto/domain/converter/IssueStatusConverter.kt
+++ b/src/main/kotlin/lotto/domain/converter/IssueStatusConverter.kt
@@ -4,4 +4,4 @@ import jakarta.persistence.Converter
 import lotto.domain.entity.IssueStatus
 
 @Converter
-class IssueStatusListConverter : EnumListToStringConverter<IssueStatus>(IssueStatus::class.java)
+class IssueStatusConverter : EnumToStringConverter<IssueStatus>(IssueStatus::class.java)

--- a/src/main/kotlin/lotto/domain/entity/IssuedLotto.kt
+++ b/src/main/kotlin/lotto/domain/entity/IssuedLotto.kt
@@ -1,16 +1,9 @@
 package lotto.domain.entity
 
 data class IssuedLotto(
-    private val issueStatus: IssueStatus,
-    private val lotto: Lotto,
+    val issueStatus: IssueStatus,
+    val lotto: Lotto,
 ) {
-    fun toIntList(): List<Int> {
-        return lotto.toIntList()
-    }
-
-    fun getIssueStatus(): IssueStatus = issueStatus
-
-    fun getLotto(): Lotto = lotto
 }
 
 enum class IssueStatus {

--- a/src/main/kotlin/lotto/domain/entity/LottoPublish.kt
+++ b/src/main/kotlin/lotto/domain/entity/LottoPublish.kt
@@ -1,7 +1,6 @@
 package lotto.domain.entity
 
 import jakarta.persistence.*
-import lotto.domain.converter.IssueStatusListConverter
 import java.time.LocalDateTime
 
 @Entity
@@ -12,23 +11,11 @@ data class LottoPublish(
     @ManyToOne(fetch = FetchType.LAZY)
     private val lottoRoundInfo: LottoRoundInfo,
     private val issuedAt: LocalDateTime,
-    @OneToMany(fetch = FetchType.LAZY)
-    @JoinTable(
-        name = "lotto_publish_lotto",
-        joinColumns = [JoinColumn(name = "lotto_publish_id")],
-        inverseJoinColumns = [JoinColumn(name = "lotto_id")],
-
-    )
-    private val lottoes: List<Lotto>,
-    @Convert(converter = IssueStatusListConverter::class)
-    private val issuedLottoesStatus: List<IssueStatus>,
     private var canceled: Boolean = false,
 ) {
-    fun getId() = id?: throw IllegalArgumentException("Not Exist Id")
+    fun getId() = id ?: throw IllegalArgumentException("Not Exist Id")
     fun getLottoRoundInfo() = lottoRoundInfo
     fun getIssuedAt() = issuedAt
-    fun getLottoes() = lottoes
-    fun getIssuedLottoesStatus() = issuedLottoesStatus
     fun getCanceled() = canceled
     fun cancel() {
         this.canceled = true

--- a/src/main/kotlin/lotto/domain/entity/LottoPublish.kt
+++ b/src/main/kotlin/lotto/domain/entity/LottoPublish.kt
@@ -13,6 +13,12 @@ data class LottoPublish(
     private val lottoRoundInfo: LottoRoundInfo,
     private val issuedAt: LocalDateTime,
     @OneToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "lotto_publish_lotto",
+        joinColumns = [JoinColumn(name = "lotto_publish_id")],
+        inverseJoinColumns = [JoinColumn(name = "lotto_id")],
+
+    )
     private val lottoes: List<Lotto>,
     @Convert(converter = IssueStatusListConverter::class)
     private val issuedLottoesStatus: List<IssueStatus>,
@@ -24,7 +30,6 @@ data class LottoPublish(
     fun getLottoes() = lottoes
     fun getIssuedLottoesStatus() = issuedLottoesStatus
     fun getCanceled() = canceled
-
     fun cancel() {
         this.canceled = true
     }

--- a/src/main/kotlin/lotto/domain/entity/PublishedLotto.kt
+++ b/src/main/kotlin/lotto/domain/entity/PublishedLotto.kt
@@ -1,0 +1,25 @@
+package lotto.domain.entity
+
+import jakarta.persistence.*
+import lotto.domain.converter.IssueStatusConverter
+
+@Entity
+@Table(name = "published_lotto")
+class PublishedLotto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lotto_publish_id", nullable = false)
+    private val lottoPublish: LottoPublish,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lotto_id", nullable = false)
+    private val lotto: Lotto,
+
+    @Convert(converter = IssueStatusConverter::class)
+    private val status: IssueStatus
+) {
+
+}

--- a/src/main/kotlin/lotto/domain/implementation/LottoPaperGenerator.kt
+++ b/src/main/kotlin/lotto/domain/implementation/LottoPaperGenerator.kt
@@ -23,32 +23,36 @@ class LottoPaperGenerator(
 
     @Transaction
     @Read
-    fun generateWithAuto(lottoPaperRequest: LottoPaperRequest): LottoPaper {
-        val paperCount = calculatePaperCount(lottoPaperRequest)
-        val issuedLottoes = createIssuedLottoes(lottoNumberGenerator.generate(paperCount), IssueStatus.AUTO)
-        return LottoPaper(issuedLottoes)
-    }
-
-    @Transaction
-    @Read
     fun generateWithNumbers(
-        lottoPaperRequest: LottoPaperRequest,
         lottoNumbers: LottoNumbers,
     ): LottoPaper {
-        val paperCount = calculatePaperCount(lottoPaperRequest)
-        require(paperCount == lottoNumbers.size()) {
-            "로또 숫자와 개수는 일치해야 합니다."
-        }
         val issuedLottoes = createIssuedLottoes(lottoNumbers, IssueStatus.MANUAL)
-        return LottoPaper(issuedLottoes)
+        val amount = calculateAmount(lottoNumbers)
+        return LottoPaper(lottoes = issuedLottoes, amount = amount)
     }
 
-    private fun calculatePaperCount(lottoPaperRequest: LottoPaperRequest): Int {
-        require(lottoPaperRequest.isDivide(UNIT)) {
-            "금액은 ${UNIT}원 단위여야 합니다."
-        }
-        return lottoPaperRequest.divide(UNIT)
+    private fun calculateAmount(lottoNumbers: LottoNumbers): BigDecimal {
+        return lottoNumbers.calculatePrice(UNIT)
     }
+
+    /**
+     * 당장 서버 내부에서 자체 생성해주는 로또는 보류한다.
+     * 2025.02.02
+     */
+//    @Transaction
+//    @Read
+//    fun generateWithAuto(lottoPaperRequest: LottoPaperRequest): LottoPaper {
+//        val paperCount = calculatePaperCount(lottoPaperRequest)
+//        val issuedLottoes = createIssuedLottoes(lottoNumberGenerator.generate(paperCount), IssueStatus.AUTO)
+//        return LottoPaper(issuedLottoes)
+//    }
+//
+//    private fun calculatePaperCount(lottoPaperRequest: LottoPaperRequest): Int {
+//        require(lottoPaperRequest.isDivide(UNIT)) {
+//            "금액은 ${UNIT}원 단위여야 합니다."
+//        }
+//        return lottoPaperRequest.divide(UNIT)
+//    }
 
     private fun createIssuedLottoes(
         lottoNumbers: LottoNumbers,

--- a/src/main/kotlin/lotto/domain/implementation/LottoPaperGenerator.kt
+++ b/src/main/kotlin/lotto/domain/implementation/LottoPaperGenerator.kt
@@ -9,7 +9,6 @@ import lotto.domain.entity.Lotto
 import lotto.domain.repository.LottoRepository
 import lotto.domain.vo.LottoNumbers
 import lotto.domain.vo.LottoPaper
-import lotto.domain.vo.LottoPaperRequest
 import java.math.BigDecimal
 
 @Implementation
@@ -58,7 +57,9 @@ class LottoPaperGenerator(
         lottoNumbers: LottoNumbers,
         issueStatus: IssueStatus,
     ): List<IssuedLotto> {
-        return getLottoEntities(lottoNumbers).map { IssuedLotto(issueStatus, it) }.toList()
+        val lottoes = getLottoEntities(lottoNumbers)
+        require(lottoNumbers.hasSize(lottoes.size)) { IllegalStateException("입력한 숫자와 조회한 숫자가 다릅니다.") }
+        return lottoes.map { IssuedLotto(issueStatus, it) }.toList()
     }
 
     private fun getLottoEntities(lottoNumbers: LottoNumbers): List<Lotto> {

--- a/src/main/kotlin/lotto/domain/implementation/LottoPublisher.kt
+++ b/src/main/kotlin/lotto/domain/implementation/LottoPublisher.kt
@@ -6,8 +6,10 @@ import common.business.Transaction
 import common.business.Write
 import lotto.domain.entity.LottoPublish
 import lotto.domain.entity.LottoRoundInfo
+import lotto.domain.entity.PublishedLotto
 import lotto.domain.repository.LottoPublishRepository
 import lotto.domain.repository.LottoRoundInfoRepository
+import lotto.domain.repository.PublishedLottoRepository
 import lotto.domain.vo.LottoPaper
 import java.time.LocalDateTime
 
@@ -15,6 +17,7 @@ import java.time.LocalDateTime
 class LottoPublisher(
     private val lottoRoundInfoRepository: LottoRoundInfoRepository,
     private val lottoPublishRepository: LottoPublishRepository,
+    private val publishedLottoRepository: PublishedLottoRepository,
 ) {
     @Transaction
     @Read
@@ -32,10 +35,15 @@ class LottoPublisher(
                 LottoPublish(
                     lottoRoundInfo = lottoInfo,
                     issuedAt = issuedAt,
-                    lottoes = lottoPaper.getLottoes(),
-                    issuedLottoesStatus = lottoPaper.getIssuedStatues(),
                 ),
             )
+        publishedLottoRepository.saveAll(lottoPaper.getLottoes().map {
+            PublishedLotto(
+                lottoPublish = lottoPublish,
+                lotto = it.lotto,
+                status = it.issueStatus,
+            )
+        })
         return lottoPublish
     }
 

--- a/src/main/kotlin/lotto/domain/implementation/LottoPublisher.kt
+++ b/src/main/kotlin/lotto/domain/implementation/LottoPublisher.kt
@@ -1,6 +1,7 @@
 package lotto.domain.implementation
 
 import common.business.Implementation
+import common.business.Read
 import common.business.Transaction
 import common.business.Write
 import lotto.domain.entity.LottoPublish
@@ -15,6 +16,13 @@ class LottoPublisher(
     private val lottoRoundInfoRepository: LottoRoundInfoRepository,
     private val lottoPublishRepository: LottoPublishRepository,
 ) {
+    @Transaction
+    @Read
+    fun findPublish(publishId: Long): LottoPublish {
+        return lottoPublishRepository.findById(publishId)
+            .orElseThrow { IllegalArgumentException("Not Exist Publish") }
+    }
+
     @Transaction
     @Write
     fun publish(issuedAt: LocalDateTime, lottoPaper: LottoPaper): LottoPublish {

--- a/src/main/kotlin/lotto/domain/repository/PublishedLottoRepository.kt
+++ b/src/main/kotlin/lotto/domain/repository/PublishedLottoRepository.kt
@@ -1,0 +1,7 @@
+package lotto.domain.repository
+
+import lotto.domain.entity.PublishedLotto
+import org.springframework.data.repository.CrudRepository
+
+interface PublishedLottoRepository : CrudRepository<PublishedLotto, Long> {
+}

--- a/src/main/kotlin/lotto/domain/vo/LottoNumbers.kt
+++ b/src/main/kotlin/lotto/domain/vo/LottoNumbers.kt
@@ -1,10 +1,16 @@
 package lotto.domain.vo
 
+import java.math.BigDecimal
+
 data class LottoNumbers(
     private val lottoNumbers: List<List<Int>>,
 ) {
-    fun size(): Int {
-        return lottoNumbers.size
+    fun hasSize(size: Int): Boolean {
+        return lottoNumbers.size == size
+    }
+
+    fun calculatePrice(unitPrice: BigDecimal): BigDecimal {
+        return unitPrice.multiply(lottoNumbers.size.toBigDecimal())
     }
 
     fun toStringWithComma(): List<String> {

--- a/src/main/kotlin/lotto/domain/vo/LottoPaper.kt
+++ b/src/main/kotlin/lotto/domain/vo/LottoPaper.kt
@@ -3,9 +3,11 @@ package lotto.domain.vo
 import lotto.domain.entity.IssueStatus
 import lotto.domain.entity.IssuedLotto
 import lotto.domain.entity.Lotto
+import java.math.BigDecimal
 
 data class LottoPaper(
     private val lottoes: List<IssuedLotto>,
+    private val amount: BigDecimal
 ) {
     companion object {
         const val MAX_PURCHASE_LIMIT = 5
@@ -28,4 +30,6 @@ data class LottoPaper(
     fun getLottoes(): List<Lotto> {
         return lottoes.stream().map { it.getLotto() }.toList()
     }
+
+    fun getAmount(): BigDecimal = amount
 }

--- a/src/main/kotlin/lotto/domain/vo/LottoPaper.kt
+++ b/src/main/kotlin/lotto/domain/vo/LottoPaper.kt
@@ -1,8 +1,6 @@
 package lotto.domain.vo
 
-import lotto.domain.entity.IssueStatus
 import lotto.domain.entity.IssuedLotto
-import lotto.domain.entity.Lotto
 import java.math.BigDecimal
 
 data class LottoPaper(
@@ -14,21 +12,13 @@ data class LottoPaper(
     }
 
     init {
-        require(lottoes.size <= 5) {
+        require(lottoes.size <= MAX_PURCHASE_LIMIT) {
             "한 번에 $MAX_PURCHASE_LIMIT 까지 구매가 가능합니다."
         }
     }
 
-    fun toIntList(): List<List<Int>> {
-        return lottoes.stream().map { it.toIntList() }.toList()
-    }
-
-    fun getIssuedStatues(): List<IssueStatus> {
-        return lottoes.stream().map { it.getIssueStatus() }.toList()
-    }
-
-    fun getLottoes(): List<Lotto> {
-        return lottoes.stream().map { it.getLotto() }.toList()
+    fun getLottoes(): List<IssuedLotto> {
+        return lottoes
     }
 
     fun getAmount(): BigDecimal = amount

--- a/src/main/kotlin/lotto/domain/vo/LottoPurchaseRequest.kt
+++ b/src/main/kotlin/lotto/domain/vo/LottoPurchaseRequest.kt
@@ -1,5 +1,6 @@
 package lotto.domain.vo
 
+import order.domain.implementation.OrderDataRequest
 import purchase.domain.vo.PurchaseRequest
 import java.math.BigDecimal
 
@@ -16,6 +17,12 @@ data class LottoPurchaseRequest(
             amount = amount,
             currency = currency.name,
             paymentKey = paymentKey,
+            orderId = orderId,
+        )
+    }
+    fun toOrderDataRequest(): OrderDataRequest {
+        return OrderDataRequest(
+            amount = amount,
             orderId = orderId,
         )
     }

--- a/src/main/kotlin/lotto/service/LottoOrderService.kt
+++ b/src/main/kotlin/lotto/service/LottoOrderService.kt
@@ -1,0 +1,39 @@
+package lotto.service
+
+import common.business.BusinessService
+import lotto.domain.entity.LottoPublish
+import lotto.domain.implementation.LottoPaperGenerator
+import lotto.domain.implementation.LottoPublisher
+import lotto.domain.vo.LottoNumbers
+import lotto.service.dto.LottoOrderData
+import order.domain.implementation.OrderProcessor
+import order.domain.vo.OrderData
+import order.domain.vo.OrderRequest
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.LocalDateTime
+
+@BusinessService
+class LottoOrderService(
+    private val lottoPaperGenerator: LottoPaperGenerator,
+    private val lottoPublisher: LottoPublisher,
+    private val orderProcessor: OrderProcessor,
+    private val clock: Clock,
+) {
+    fun saveLottoOrder(
+        lottoNumbers: LottoNumbers
+    ): LottoOrderData {
+        val (lottoPublish, amount) = publish(lottoNumbers)
+        val order = orderProcessor.saveOrder(OrderRequest(amount))
+        return LottoOrderData(
+            lottoPublishId = lottoPublish.getId(),
+            orderData = OrderData.from(order)
+        )
+    }
+
+    private fun publish(lottoNumbers: LottoNumbers): Pair<LottoPublish, BigDecimal> {
+        val issuedAt = LocalDateTime.now(clock)
+        val lottoPaper = lottoPaperGenerator.generateWithNumbers(lottoNumbers)
+        return Pair(lottoPublisher.publish(issuedAt, lottoPaper), lottoPaper.getAmount())
+    }
+}

--- a/src/main/kotlin/lotto/service/dto/LottoOrderData.kt
+++ b/src/main/kotlin/lotto/service/dto/LottoOrderData.kt
@@ -1,0 +1,9 @@
+package lotto.service.dto
+
+import order.domain.vo.OrderData
+
+class LottoOrderData(
+    val lottoPublishId:Long,
+    val orderData: OrderData
+) {
+}

--- a/src/main/kotlin/lotto/service/dto/LottoPurchaseData.kt
+++ b/src/main/kotlin/lotto/service/dto/LottoPurchaseData.kt
@@ -37,14 +37,12 @@ data class PurchaseData(
 
 data class LottoPublishData(
     val id: Long,
-    val numbers: List<Lotto>,
     val isCanceled: Boolean
 ) {
     companion object {
         fun from(lottoPublish: LottoPublish): LottoPublishData {
             return LottoPublishData(
                 id = lottoPublish.getId(),
-                numbers = lottoPublish.getLottoes(),
                 isCanceled = lottoPublish.getCanceled()
             )
         }

--- a/src/main/kotlin/order/config/OrderClockConfig.kt
+++ b/src/main/kotlin/order/config/OrderClockConfig.kt
@@ -1,11 +1,11 @@
-package lotto.config
+package order.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.time.Clock
 
 @Configuration
-class ClockConfig {
+class OrderClockConfig {
     @Bean
     fun clock(): Clock = Clock.systemDefaultZone()
 }

--- a/src/main/kotlin/order/domain/implementation/OrderIdGenerator.kt
+++ b/src/main/kotlin/order/domain/implementation/OrderIdGenerator.kt
@@ -1,0 +1,11 @@
+package order.domain.implementation
+
+import common.business.Implementation
+import java.util.*
+
+@Implementation
+class OrderIdGenerator {
+    fun getOrderId(): UUID {
+        return UUID.randomUUID()
+    }
+}

--- a/src/main/kotlin/order/domain/implementation/OrderProcessor.kt
+++ b/src/main/kotlin/order/domain/implementation/OrderProcessor.kt
@@ -1,0 +1,26 @@
+package order.domain.implementation
+
+import common.business.Implementation
+import common.business.Transaction
+import common.business.Write
+import order.domain.vo.OrderRequest
+import purchase.domain.entity.Order
+import order.domain.repository.OrderRepository
+
+@Implementation
+class OrderProcessor(
+    private val orderRepository: OrderRepository,
+    private val orderIdGenerator: OrderIdGenerator
+) {
+    @Transaction
+    @Write
+    fun saveOrder(orderRequest: OrderRequest): Order {
+        val orderId = orderIdGenerator.getOrderId()
+        return orderRepository.save(
+            Order(
+                orderId = orderId.toString(),
+                amount = orderRequest.amount
+            )
+        )
+    }
+}

--- a/src/main/kotlin/order/domain/implementation/OrderValidator.kt
+++ b/src/main/kotlin/order/domain/implementation/OrderValidator.kt
@@ -1,0 +1,30 @@
+package order.domain.implementation
+
+import common.business.Implementation
+import common.business.Read
+import common.business.Transaction
+import order.domain.repository.OrderRepository
+import purchase.domain.PurchaseException
+import purchase.domain.PurchaseExceptionCode
+import java.math.BigDecimal
+
+@Implementation
+class OrderValidator(
+    private val orderRepository: OrderRepository,
+) {
+    @Transaction
+    @Read
+    fun checkOrderValid(request: OrderDataRequest) {
+        val orderData = orderRepository.findByOrderId(request.orderId).orElseThrow {
+            PurchaseException(PurchaseExceptionCode.NOT_EXIST_ORDER_ID)
+        }
+        if (orderData.isNotEqualAmount(request.amount)) {
+            throw PurchaseException(PurchaseExceptionCode.NOT_VALID_ORDER_ID)
+        }
+    }
+}
+
+data class OrderDataRequest(
+    val orderId: String,
+    val amount: BigDecimal,
+)

--- a/src/main/kotlin/order/domain/repository/OrderRepository.kt
+++ b/src/main/kotlin/order/domain/repository/OrderRepository.kt
@@ -1,0 +1,9 @@
+package order.domain.repository
+
+import org.springframework.data.repository.CrudRepository
+import purchase.domain.entity.Order
+import java.util.*
+
+interface OrderRepository : CrudRepository<Order, UUID> {
+    fun findByOrderId(orderId: String): Optional<Order>
+}

--- a/src/main/kotlin/order/domain/vo/OrderData.kt
+++ b/src/main/kotlin/order/domain/vo/OrderData.kt
@@ -1,0 +1,18 @@
+package order.domain.vo
+
+import purchase.domain.entity.Order
+import java.math.BigDecimal
+
+class OrderData(
+    val orderId: String,
+    val amount: BigDecimal
+) {
+    companion object {
+        fun from(order: Order): OrderData {
+            return OrderData(
+                orderId = order.getOrderId(),
+                amount = order.getAmount()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/order/domain/vo/OrderRequest.kt
+++ b/src/main/kotlin/order/domain/vo/OrderRequest.kt
@@ -1,0 +1,8 @@
+package order.domain.vo
+
+import java.math.BigDecimal
+
+data class OrderRequest(
+    val amount: BigDecimal
+) {
+}

--- a/src/main/kotlin/purchase/domain/entity/Order.kt
+++ b/src/main/kotlin/purchase/domain/entity/Order.kt
@@ -3,10 +3,12 @@ package purchase.domain.entity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
+import jakarta.persistence.Table
 import java.math.BigDecimal
 
 @Entity
-class PurchaseTemporary(
+@Table(name = "orders")
+class Order(
     @Id
     @Column(unique = true)
     private val orderId: String,

--- a/src/main/kotlin/purchase/domain/implementation/PurchaseProcessor.kt
+++ b/src/main/kotlin/purchase/domain/implementation/PurchaseProcessor.kt
@@ -17,7 +17,6 @@ class PurchaseProcessor(
     }
 
     fun purchase(purchaseRequest: PurchaseRequest): Purchase {
-        purchaseValidator.checkOrderValid(purchaseRequest.toOrderDataRequest())
         val purchaseData = paymentProcessor.purchase(purchaseRequest, PurchaseProvider.TOSS)
         val purchase = purchaseWriter.savePurchase(purchaseData)
         return purchase

--- a/src/main/kotlin/purchase/domain/implementation/PurchaseValidator.kt
+++ b/src/main/kotlin/purchase/domain/implementation/PurchaseValidator.kt
@@ -1,41 +1,13 @@
 package purchase.domain.implementation
 
 import common.business.Implementation
-import common.business.Read
-import common.business.Transaction
-import common.business.Write
 import purchase.domain.PurchaseException
 import purchase.domain.PurchaseExceptionCode
 import purchase.domain.entity.Purchase
-import purchase.domain.entity.PurchaseTemporary
-import purchase.domain.repository.PurchaseTemporaryRepository
 import java.math.BigDecimal
 
 @Implementation
-class PurchaseValidator(
-    private val purchaseTemporaryRepository: PurchaseTemporaryRepository,
-) {
-    @Transaction
-    @Write
-    fun saveTemporary(request: OrderDataRequest): PurchaseTemporary {
-        return purchaseTemporaryRepository.save(
-            PurchaseTemporary(
-                orderId = request.orderId,
-                amount = request.amount
-            )
-        )
-    }
-
-    @Transaction
-    @Read
-    fun checkOrderValid(request: OrderDataRequest) {
-        val orderData = purchaseTemporaryRepository.findByOrderId(request.orderId).orElseThrow {
-            PurchaseException(PurchaseExceptionCode.NOT_EXIST_ORDER_ID)
-        }
-        if (orderData.isNotEqualAmount(request.amount)) {
-            throw PurchaseException(PurchaseExceptionCode.NOT_VALID_ORDER_ID)
-        }
-    }
+class PurchaseValidator {
 
     fun checkCancelValid(purchase: Purchase) {
         if (purchase.isCanceled()) {
@@ -46,8 +18,3 @@ class PurchaseValidator(
         }
     }
 }
-
-data class OrderDataRequest(
-    val orderId: String,
-    val amount: BigDecimal,
-)

--- a/src/main/kotlin/purchase/domain/repository/PurchaseTemporaryRepository.kt
+++ b/src/main/kotlin/purchase/domain/repository/PurchaseTemporaryRepository.kt
@@ -1,9 +1,0 @@
-package purchase.domain.repository
-
-import org.springframework.data.repository.CrudRepository
-import purchase.domain.entity.PurchaseTemporary
-import java.util.*
-
-interface PurchaseTemporaryRepository : CrudRepository<PurchaseTemporary, UUID> {
-    fun findByOrderId(orderId: String): Optional<PurchaseTemporary>
-}

--- a/src/main/kotlin/purchase/domain/vo/PurchaseRequest.kt
+++ b/src/main/kotlin/purchase/domain/vo/PurchaseRequest.kt
@@ -1,6 +1,5 @@
 package purchase.domain.vo
 
-import purchase.domain.implementation.OrderDataRequest
 import java.math.BigDecimal
 
 data class PurchaseRequest(
@@ -10,10 +9,4 @@ data class PurchaseRequest(
     val paymentKey: String,
     val orderId: String,
 ) {
-    fun toOrderDataRequest(): OrderDataRequest {
-        return OrderDataRequest(
-            amount = amount,
-            orderId = orderId,
-        )
-    }
 }

--- a/src/main/resources/config/application-local.yml
+++ b/src/main/resources/config/application-local.yml
@@ -24,3 +24,6 @@ toss:
     api-key: test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
     payment-url: /v1/payments/confirm
     cancel-url: /v1/payments/{paymentKey}/cancel
+
+cors:
+  allowed-origins: http://localhost:3000

--- a/src/test/kotlin/AcceptanceFunction.kt
+++ b/src/test/kotlin/AcceptanceFunction.kt
@@ -1,0 +1,28 @@
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import org.springframework.restdocs.payload.RequestFieldsSnippet
+import org.springframework.restdocs.payload.ResponseFieldsSnippet
+import org.springframework.restdocs.restassured.RestAssuredRestDocumentation
+
+fun sendRequest(
+    request: Map<String, Any>,
+    documentName: String,
+    requestFields: RequestFieldsSnippet,
+    responseFields: ResponseFieldsSnippet,
+    expectedStatus: Int,
+    url: String,
+    map: Map<String, Any> = HashMap()
+) {
+    RestAssured.given().log().all()
+        .contentType(ContentType.JSON)
+        .headers(map)
+        .body(request)
+        .filter(
+            RestAssuredRestDocumentation.document(
+                documentName,
+                requestFields,
+                responseFields
+            )
+        )
+        .post(url).then().log().all().statusCode(expectedStatus).extract()
+}

--- a/src/test/kotlin/config/AcceptanceConfig.kt
+++ b/src/test/kotlin/config/AcceptanceConfig.kt
@@ -8,11 +8,6 @@ import purchase.domain.implementation.TestPaymentClient
 
 @TestConfiguration
 class AcceptanceConfig {
-    @Bean
-    @Primary
-    fun lottoRepositoryImpl(): LottoRepositoryImpl {
-        return LottoRepositoryImpl()
-    }
 
     @Bean
     @Primary

--- a/src/test/kotlin/lotto/controller/LottoOrderTest.kt
+++ b/src/test/kotlin/lotto/controller/LottoOrderTest.kt
@@ -20,7 +20,7 @@ class LottoOrderTest {
             commonRequestFields(),
             successResponseFields(),
             200,
-            "/api/order"
+            "/api/orders"
         )
     }
 

--- a/src/test/kotlin/lotto/controller/LottoOrderTest.kt
+++ b/src/test/kotlin/lotto/controller/LottoOrderTest.kt
@@ -1,0 +1,46 @@
+package lotto.controller
+
+import config.AcceptanceTest
+import org.junit.jupiter.api.Test
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.*
+import sendRequest
+
+@AcceptanceTest(["/acceptance/lottoOrder.json"])
+class LottoOrderTest {
+    @Test
+    fun `결제승인을 통해 성공적으로 결제를 진행한다`() {
+        val request = createRequest(
+            numbers = listOf(listOf(1, 10, 11, 14, 15, 17))
+        )
+
+        sendRequest(
+            request,
+            "order-success",
+            commonRequestFields(),
+            successResponseFields(),
+            200,
+            "/api/order"
+        )
+    }
+
+    private fun createRequest(
+        numbers: List<List<Int>>,
+    ): Map<String, Any> {
+        return mapOf(
+            "numbers" to numbers
+        )
+    }
+    private fun commonRequestFields() = requestFields(
+        fieldWithPath("numbers").type(JsonFieldType.ARRAY).description("구매할 로또 번호 목록"),
+        fieldWithPath("numbers[].[]").type(JsonFieldType.ARRAY).description("로또 번호")
+    )
+
+    private fun successResponseFields() = responseFields(
+        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+        fieldWithPath("status").type(JsonFieldType.NUMBER).description("응답 상태"),
+        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+        fieldWithPath("data.lottoPublishId").type(JsonFieldType.NUMBER).description("발행된 로또 ID"),
+        fieldWithPath("data.orderId").type(JsonFieldType.STRING).description("저장된 주문번호 ID"),
+    )
+}

--- a/src/test/kotlin/lotto/domain/LottoPaperGeneratorTest.kt
+++ b/src/test/kotlin/lotto/domain/LottoPaperGeneratorTest.kt
@@ -4,6 +4,8 @@ import config.FixtureLottoNumberGenerator
 import config.ImplementationTest
 import config.LottoRepositoryImpl
 import lotto.domain.entity.IssueStatus
+import lotto.domain.entity.IssuedLotto
+import lotto.domain.entity.Lotto
 import lotto.domain.implementation.LottoNumberGenerator
 import lotto.domain.implementation.LottoPaperGenerator
 import lotto.domain.vo.LottoNumbers
@@ -29,13 +31,12 @@ class LottoPaperGeneratorTest {
             generator.generateWithNumbers(
                 LottoNumbers(listOf(listOf(1, 14, 17, 19, 21, 34), listOf(23, 27, 39, 40, 41, 43))),
             )
-        assertThat(response.toIntList()).isEqualTo(
+        assertThat(response.getLottoes()).isEqualTo(
             listOf(
-                listOf(1, 14, 17, 19, 21, 34),
-                listOf(23, 27, 39, 40, 41, 43),
+                IssuedLotto(issueStatus = IssueStatus.MANUAL, lotto = Lotto(listOf(1, 14, 17, 19, 21, 34))),
+                IssuedLotto(issueStatus = IssueStatus.MANUAL, lotto = Lotto(listOf(23, 27, 39, 40, 41, 43))),
             ),
         )
-        assertThat(response.getIssuedStatues()).isEqualTo(listOf(IssueStatus.MANUAL, IssueStatus.MANUAL))
     }
 
 //    @ParameterizedTest

--- a/src/test/kotlin/lotto/domain/LottoPaperGeneratorTest.kt
+++ b/src/test/kotlin/lotto/domain/LottoPaperGeneratorTest.kt
@@ -7,90 +7,18 @@ import lotto.domain.entity.IssueStatus
 import lotto.domain.implementation.LottoNumberGenerator
 import lotto.domain.implementation.LottoPaperGenerator
 import lotto.domain.vo.LottoNumbers
-import lotto.domain.vo.LottoPaperRequest
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
-import java.math.BigDecimal
 import kotlin.test.Test
 
 @ImplementationTest
 class LottoPaperGeneratorTest {
-    
+
     @Autowired
     private lateinit var lottoRepository: LottoRepositoryImpl
 
     @Test
-    fun `금액에 맞게 자동으로 숫자를 생성한다1`() {
-        val generator =
-            LottoPaperGenerator(
-                lottoNumberGenerator =
-                lottoNumberGenerator(
-                    listOf(
-                        listOf(1, 14, 17, 19, 21, 34),
-                    ),
-                ),
-                lottoRepository = lottoRepository,
-            )
-        val response =
-            generator.generateWithAuto(
-                lottoPaperRequest = LottoPaperRequest(BigDecimal(1000)),
-            )
-
-        assertThat(response.toIntList()).isEqualTo(listOf(listOf(1, 14, 17, 19, 21, 34)))
-        assertThat(response.getIssuedStatues()).isEqualTo(listOf(IssueStatus.AUTO))
-    }
-
-    @Test
-    fun `금액에 맞게 자동으로 숫자를 생성한다2`() {
-        val generator =
-            LottoPaperGenerator(
-                lottoNumberGenerator =
-                lottoNumberGenerator(
-                    listOf(
-                        listOf(1, 14, 17, 19, 21, 34),
-                        listOf(23, 27, 39, 40, 41, 43),
-                    ),
-                ),
-                lottoRepository = lottoRepository,
-            )
-
-        val response =
-            generator.generateWithAuto(
-                lottoPaperRequest = LottoPaperRequest(BigDecimal(2000)),
-            )
-        assertThat(response.toIntList()).isEqualTo(
-            listOf(
-                listOf(1, 14, 17, 19, 21, 34),
-                listOf(23, 27, 39, 40, 41, 43),
-            ),
-        )
-        assertThat(response.getIssuedStatues()).isEqualTo(listOf(IssueStatus.AUTO, IssueStatus.AUTO))
-    }
-
-    @Test
-    fun `금액이 기준에 맞지 않으면 예외를 발생한다`() {
-        val generator =
-            LottoPaperGenerator(
-                lottoNumberGenerator =
-                lottoNumberGenerator(
-                    listOf(
-                        listOf(1, 14, 17, 19, 21, 34),
-                    ),
-                ),
-                lottoRepository = lottoRepository,
-            )
-        assertThrows<IllegalArgumentException> {
-            generator.generateWithAuto(
-                lottoPaperRequest = LottoPaperRequest(BigDecimal(1500)),
-            )
-        }
-    }
-
-    @Test
-    fun `금액에 맞게 수동으로 생성한다`() {
+    fun `로또 종이를 생성한다`() {
         val generator =
             LottoPaperGenerator(
                 lottoNumberGenerator = lottoNumberGenerator(),
@@ -99,7 +27,6 @@ class LottoPaperGeneratorTest {
 
         val response =
             generator.generateWithNumbers(
-                lottoPaperRequest = LottoPaperRequest(BigDecimal(2000)),
                 LottoNumbers(listOf(listOf(1, 14, 17, 19, 21, 34), listOf(23, 27, 39, 40, 41, 43))),
             )
         assertThat(response.toIntList()).isEqualTo(
@@ -111,22 +38,21 @@ class LottoPaperGeneratorTest {
         assertThat(response.getIssuedStatues()).isEqualTo(listOf(IssueStatus.MANUAL, IssueStatus.MANUAL))
     }
 
-    @ParameterizedTest
-    @ValueSource(ints = [1000, 3000])
-    fun `금액보다 더 많거나,적은 요청 시 예외를 발생한다`(value: Int) {
-        val generator =
-            LottoPaperGenerator(
-                lottoNumberGenerator = lottoNumberGenerator(),
-                lottoRepository = lottoRepository,
-            )
-
-        assertThrows<IllegalArgumentException> {
-            generator.generateWithNumbers(
-                lottoPaperRequest = LottoPaperRequest(BigDecimal(value)),
-                LottoNumbers(listOf(listOf(1, 14, 17, 19, 21, 34), listOf(23, 27, 39, 40, 41, 43))),
-            )
-        }
-    }
+//    @ParameterizedTest
+//    @ValueSource(ints = [1000, 3000])
+//    fun `금액보다 더 많거나,적은 요청 시 예외를 발생한다`(value: Int) {
+//        val generator =
+//            LottoPaperGenerator(
+//                lottoNumberGenerator = lottoNumberGenerator(),
+//                lottoRepository = lottoRepository,
+//            )
+//
+//        assertThrows<IllegalArgumentException> {
+//            generator.generateWithNumbers(
+//                LottoNumbers(listOf(listOf(1, 14, 17, 19, 21, 34), listOf(23, 27, 39, 40, 41, 43))),
+//            )
+//        }
+//    }
 
     private fun lottoNumberGenerator(numbers: List<List<Int>> = listOf()): LottoNumberGenerator {
         return FixtureLottoNumberGenerator(numbers)

--- a/src/test/kotlin/lotto/domain/LottoPublisherTest.kt
+++ b/src/test/kotlin/lotto/domain/LottoPublisherTest.kt
@@ -5,11 +5,9 @@ import config.MockingClock
 import lotto.Fixture
 import lotto.domain.entity.LottoStatus
 import lotto.domain.implementation.LottoPublisher
-import lotto.domain.repository.LottoPublishRepository
 import lotto.domain.repository.LottoRoundInfoRepository
 import lotto.domain.vo.LottoPaper
 import lotto.fixture.IssuedLottoBuilder
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
@@ -19,24 +17,16 @@ import kotlin.test.Test
 @ImplementationTest
 class LottoPublisherTest {
     @Autowired
-    private lateinit var lottoRoundInfoRepository: LottoRoundInfoRepository
+    private lateinit var clock: MockingClock
 
     @Autowired
-    private lateinit var lottoPublishRepository: LottoPublishRepository
+    private lateinit var lottoRoundInfoRepository:LottoRoundInfoRepository
 
-    private val clock = MockingClock()
+    @Autowired
     private lateinit var lottoPublisher: LottoPublisher
     private val startDate = LocalDateTime.now()
     private val endDate = startDate.plusDays(1)
 
-    @BeforeEach
-    fun setup() {
-        lottoPublisher =
-            LottoPublisher(
-                lottoRoundInfoRepository = lottoRoundInfoRepository,
-                lottoPublishRepository = lottoPublishRepository,
-            )
-    }
 
     @Test
     fun `현재 해당하는 회차가 없으면 예외를 발생한다 - 시작일 이전`() {

--- a/src/test/kotlin/lotto/domain/LottoPublisherTest.kt
+++ b/src/test/kotlin/lotto/domain/LottoPublisherTest.kt
@@ -12,6 +12,7 @@ import lotto.fixture.IssuedLottoBuilder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
 import java.time.LocalDateTime
 import kotlin.test.Test
 
@@ -94,6 +95,7 @@ class LottoPublisherTest {
                         .withNumbers(listOf(1, 3, 5, 11, 13, 15))
                         .build(),
                 ),
+                amount = BigDecimal(2000),
             ),
         )
     }

--- a/src/test/kotlin/lotto/domain/implementation/LottoPurchaseProcessorTest.kt
+++ b/src/test/kotlin/lotto/domain/implementation/LottoPurchaseProcessorTest.kt
@@ -5,90 +5,25 @@ import config.ImplementationTest
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.spring.SpringExtension
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
-import lotto.domain.vo.Currency
-import lotto.domain.vo.PurchaseType
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.context.annotation.Import
 import purchase.domain.PurchaseException
-import purchase.domain.PurchaseExceptionCode
 import purchase.domain.entity.Purchase
 import purchase.domain.entity.PurchaseInfo
-import purchase.domain.implementation.OrderDataRequest
 import purchase.domain.implementation.PurchaseProcessor
-import purchase.domain.implementation.PurchaseValidator
 import purchase.domain.repository.PurchaseRepository
 import purchase.domain.vo.PaymentMethod
 import purchase.domain.vo.PurchaseProvider
-import purchase.domain.vo.PurchaseRequest
 import java.math.BigDecimal
 
 @ImplementationTest
 @Import(TestConfig::class)
 class LottoPurchaseProcessorTest(
     private val purchaseProcessor: PurchaseProcessor,
-    private val purchaseValidator: PurchaseValidator,
     private val purchaseRepository: PurchaseRepository
 ) : FunSpec({
-    val orderId = "orderId"
-    val paymentKey = "paymentKey"
-    val amount = BigDecimal(1000)
     extensions(listOf(SpringExtension))
 
-    context("주문에 대한 사전 정보가 있는지 확인한다") {
-        beforeTest {
-            purchaseValidator.saveTemporary(
-                request = OrderDataRequest(
-                    orderId = orderId,
-                    amount = amount
-                )
-            )
-        }
-        test("사전 정보와 일치한지 검증한다.") {
-            val result = purchaseProcessor.purchase(
-                PurchaseRequest(
-                    purchaseType = PurchaseType.CARD.name,
-                    amount = BigDecimal(1000),
-                    orderId = orderId,
-                    paymentKey = paymentKey,
-                    currency = Currency.KRW.name
-                )
-            )
-            result.isSuccess() shouldBe true
-            result.getId() shouldNotBe null
-        }
-
-        test("orderId 에 해당하는 값이 없으면 예외를 발생한다.") {
-            val exception = shouldThrow<PurchaseException> {
-                purchaseProcessor.purchase(
-                    PurchaseRequest(
-                        purchaseType = PurchaseType.CARD.name,
-                        amount = amount,
-                        orderId = "not Exist",
-                        paymentKey = paymentKey,
-                        currency = Currency.KRW.name
-                    )
-                )
-            }
-            exception.purchaseExceptionCode shouldBe PurchaseExceptionCode.NOT_EXIST_ORDER_ID
-        }
-
-        test("Id 에 해당하는 금액이 다르면 예외를 발생한다.") {
-            val exception = shouldThrow<PurchaseException> {
-                purchaseProcessor.purchase(
-                    PurchaseRequest(
-                        purchaseType = PurchaseType.CARD.name,
-                        amount = BigDecimal(1500),
-                        orderId = orderId,
-                        paymentKey = paymentKey,
-                        currency = Currency.KRW.name
-                    )
-                )
-            }
-            exception.purchaseExceptionCode shouldBe PurchaseExceptionCode.NOT_VALID_ORDER_ID
-        }
-    }
     context("결제 취소") {
         val failPurchase = purchaseRepository.save(
             Purchase(

--- a/src/test/kotlin/lotto/domain/vo/LottoPaperTest.kt
+++ b/src/test/kotlin/lotto/domain/vo/LottoPaperTest.kt
@@ -1,0 +1,31 @@
+package lotto.domain.vo
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import lotto.domain.entity.IssueStatus
+import lotto.domain.entity.IssuedLotto
+import lotto.domain.entity.Lotto
+import java.math.BigDecimal
+
+class LottoPaperTest : FunSpec({
+
+    context("로또 페이퍼 식별자 생성") {
+        test("ID와 발급 상태들로 생성한다.") {
+            val lottoPaper = LottoPaper(
+                listOf(
+                    IssuedLotto(
+                        issueStatus = IssueStatus.MANUAL,
+                        lotto = Lotto(id = 1, numbers = listOf(1, 2, 3, 11, 14, 17))
+                    ),
+                    IssuedLotto(
+                        issueStatus = IssueStatus.AUTO,
+                        lotto = Lotto(id = 2, numbers = listOf(1, 2, 3, 11, 14, 31))
+                    )
+                ),
+                amount = BigDecimal(2000)
+            )
+            lottoPaper.getLottoes().map { it.getId() } shouldBe listOf(1, 2)
+            lottoPaper.getIssuedStatues() shouldBe listOf(IssueStatus.MANUAL, IssueStatus.AUTO)
+        }
+    }
+})

--- a/src/test/kotlin/lotto/domain/vo/LottoPaperTest.kt
+++ b/src/test/kotlin/lotto/domain/vo/LottoPaperTest.kt
@@ -1,31 +1,26 @@
 package lotto.domain.vo
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.shouldBe
 import lotto.domain.entity.IssueStatus
 import lotto.domain.entity.IssuedLotto
 import lotto.domain.entity.Lotto
+import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
 
 class LottoPaperTest : FunSpec({
 
-    context("로또 페이퍼 식별자 생성") {
-        test("ID와 발급 상태들로 생성한다.") {
-            val lottoPaper = LottoPaper(
-                listOf(
-                    IssuedLotto(
-                        issueStatus = IssueStatus.MANUAL,
-                        lotto = Lotto(id = 1, numbers = listOf(1, 2, 3, 11, 14, 17))
-                    ),
-                    IssuedLotto(
-                        issueStatus = IssueStatus.AUTO,
-                        lotto = Lotto(id = 2, numbers = listOf(1, 2, 3, 11, 14, 31))
-                    )
-                ),
+    test("로또가 5개 이상이면 예외를 발생한다.") {
+        val lotto = List(6) {
+            IssuedLotto(
+                issueStatus = IssueStatus.MANUAL,
+                lotto = Lotto(id = 1, numbers = listOf(1, 2, 3, 11, 14, 17))
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            LottoPaper(
+                lotto,
                 amount = BigDecimal(2000)
             )
-            lottoPaper.getLottoes().map { it.getId() } shouldBe listOf(1, 2)
-            lottoPaper.getIssuedStatues() shouldBe listOf(IssueStatus.MANUAL, IssueStatus.AUTO)
         }
     }
 })

--- a/src/test/kotlin/lotto/service/LottoOrderServiceTest.kt
+++ b/src/test/kotlin/lotto/service/LottoOrderServiceTest.kt
@@ -1,0 +1,56 @@
+package lotto.service
+
+import app.TestConfig
+import config.ImplementationTest
+import lotto.domain.entity.LottoRoundInfo
+import lotto.domain.repository.LottoRoundInfoRepository
+import lotto.domain.vo.LottoNumbers
+import order.domain.repository.OrderRepository
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+import java.time.LocalDateTime
+
+@ImplementationTest
+@Import(TestConfig::class)
+class LottoOrderServiceTest {
+    @Autowired
+    private lateinit var lottoOrderService: LottoOrderService
+
+    @Autowired
+    private lateinit var lottoRoundInfoRepository: LottoRoundInfoRepository
+
+    @Autowired
+    private lateinit var orderRepository: OrderRepository
+
+    @Nested
+    inner class OrderCase {
+        private val dateTime = LocalDateTime.now()
+
+        @BeforeEach
+        fun setUp() {
+            lottoRoundInfoRepository.save(
+                LottoRoundInfo(
+                    null,
+                    round = 1,
+                    startDate = dateTime.minusHours(1),
+                    endDate = dateTime.plusHours(1),
+                    drawDate = dateTime.plusHours(2),
+                    paymentDeadline = dateTime.plusYears(1),
+                ),
+            )
+        }
+
+        @Test
+        fun `주문이 성공적으로 진행된다`() {
+            assertDoesNotThrow {
+                lottoOrderService.saveLottoOrder(
+                    lottoNumbers = LottoNumbers(listOf(listOf(1, 14, 17, 19, 21, 23)))
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/lotto/service/LottoOrderServiceTest.kt
+++ b/src/test/kotlin/lotto/service/LottoOrderServiceTest.kt
@@ -3,10 +3,11 @@ package lotto.service
 import app.TestConfig
 import config.ImplementationTest
 import lotto.domain.entity.LottoRoundInfo
+import lotto.domain.repository.LottoPublishRepository
 import lotto.domain.repository.LottoRoundInfoRepository
 import lotto.domain.vo.LottoNumbers
 import order.domain.repository.OrderRepository
-import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -25,6 +26,9 @@ class LottoOrderServiceTest {
 
     @Autowired
     private lateinit var orderRepository: OrderRepository
+
+    @Autowired
+    private lateinit var lottoPublishRepository: LottoPublishRepository
 
     @Nested
     inner class OrderCase {
@@ -51,6 +55,23 @@ class LottoOrderServiceTest {
                     lottoNumbers = LottoNumbers(listOf(listOf(1, 14, 17, 19, 21, 23)))
                 )
             }
+        }
+
+        @Test
+        fun `모든 컴포넌트가 정상적으로 상호작용하여 주문을 처리한다`() {
+            // Given
+            val lottoNumbers = LottoNumbers(listOf(listOf(1, 14, 17, 19, 21, 23)))
+
+            // When
+            val result = lottoOrderService.saveLottoOrder(lottoNumbers)
+
+            // Then
+            val savedOrder = orderRepository.findByOrderId(result.orderData.orderId)
+            assertTrue(savedOrder.isPresent)
+            assertEquals(result.orderData.amount, savedOrder.get().getAmount().setScale(0))
+
+            val lottoPublish = lottoPublishRepository.findById(result.lottoPublishId)
+            assertTrue(lottoPublish.isPresent)
         }
     }
 }

--- a/src/test/kotlin/lotto/service/LottoPurchaseServiceTest.kt
+++ b/src/test/kotlin/lotto/service/LottoPurchaseServiceTest.kt
@@ -8,20 +8,19 @@ import lotto.domain.repository.LottoPublishRepository
 import lotto.domain.repository.LottoRepository
 import lotto.domain.repository.LottoRoundInfoRepository
 import lotto.domain.vo.Currency
-import lotto.domain.vo.LottoNumbers
 import lotto.domain.vo.LottoPurchaseRequest
 import lotto.domain.vo.PurchaseType
+import order.domain.repository.OrderRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
+import purchase.domain.entity.Order
 import purchase.domain.entity.Purchase
 import purchase.domain.entity.PurchaseInfo
-import purchase.domain.entity.PurchaseTemporary
 import purchase.domain.repository.PurchaseRepository
-import purchase.domain.repository.PurchaseTemporaryRepository
 import purchase.domain.vo.PaymentMethod
 import purchase.domain.vo.PurchaseProvider
 import java.math.BigDecimal
@@ -38,7 +37,9 @@ class LottoPurchaseServiceTest {
     private lateinit var lottoRoundInfoRepository: LottoRoundInfoRepository
 
     @Autowired
-    private lateinit var purchaseTemporaryRepository: PurchaseTemporaryRepository
+    private lateinit var orderRepository: OrderRepository
+
+    private var lottoPublishId: Long = 0
 
     private val dateTime = LocalDateTime.now()
 
@@ -46,7 +47,7 @@ class LottoPurchaseServiceTest {
     inner class PurchaseCase {
         @BeforeEach
         fun setUp() {
-            lottoRoundInfoRepository.save(
+            val roundInfo = lottoRoundInfoRepository.save(
                 LottoRoundInfo(
                     null,
                     round = 1,
@@ -56,12 +57,20 @@ class LottoPurchaseServiceTest {
                     paymentDeadline = dateTime.plusYears(1),
                 ),
             )
-            purchaseTemporaryRepository.save(
-                PurchaseTemporary(
+            orderRepository.save(
+                Order(
                     orderId = "orderId",
                     amount = BigDecimal(1000)
                 )
             )
+            lottoPublishId = lottoPublishRepository.save(
+                LottoPublish(
+                    lottoRoundInfo = roundInfo,
+                    lottoes = listOf(lottoRepository.save(Lotto(listOf(1, 10, 11, 14, 17, 19)))),
+                    issuedAt = LocalDateTime.now(),
+                    issuedLottoesStatus = listOf(IssueStatus.MANUAL)
+                )
+            ).getId()
         }
 
         @Test
@@ -75,7 +84,7 @@ class LottoPurchaseServiceTest {
                         paymentKey = "paymentKey",
                         orderId = "orderId"
                     ),
-                    lottoNumbers = LottoNumbers(listOf(listOf(1, 14, 17, 19, 21, 34)))
+                    lottoPublishId = lottoPublishId
                 )
             }
         }

--- a/src/test/kotlin/lotto/service/LottoPurchaseServiceTest.kt
+++ b/src/test/kotlin/lotto/service/LottoPurchaseServiceTest.kt
@@ -66,9 +66,7 @@ class LottoPurchaseServiceTest {
             lottoPublishId = lottoPublishRepository.save(
                 LottoPublish(
                     lottoRoundInfo = roundInfo,
-                    lottoes = listOf(lottoRepository.save(Lotto(listOf(1, 10, 11, 14, 17, 19)))),
                     issuedAt = LocalDateTime.now(),
-                    issuedLottoesStatus = listOf(IssueStatus.MANUAL)
                 )
             ).getId()
         }
@@ -99,9 +97,6 @@ class LottoPurchaseServiceTest {
     @Autowired
     private lateinit var lottoBillRepository: LottoBillRepository
 
-    @Autowired
-    private lateinit var lottoRepository: LottoRepository
-
     @Nested
     inner class CancelCase {
         private lateinit var bill: LottoBill
@@ -121,8 +116,6 @@ class LottoPurchaseServiceTest {
                         ),
                     ),
                     issuedAt = dateTime,
-                    lottoes = listOf(lottoRepository.save(Lotto(listOf(1, 5, 7, 11, 13, 15)))),
-                    issuedLottoesStatus = listOf(IssueStatus.AUTO),
                 )
             )
             val purchase = purchaseRepository.save(

--- a/src/test/kotlin/order/domain/implementation/OrderValidatorTest.kt
+++ b/src/test/kotlin/order/domain/implementation/OrderValidatorTest.kt
@@ -1,0 +1,70 @@
+package order.domain.implementation
+
+import app.TestConfig
+import config.ImplementationTest
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import order.domain.repository.OrderRepository
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.springframework.context.annotation.Import
+import purchase.domain.PurchaseException
+import purchase.domain.PurchaseExceptionCode
+import purchase.domain.entity.Order
+import java.math.BigDecimal
+
+@ImplementationTest
+@Import(TestConfig::class)
+class OrderValidatorTest(
+    private val orderRepository: OrderRepository,
+    private val orderValidator: OrderValidator
+) : FunSpec({
+    extensions(listOf(SpringExtension))
+    context("주문에 대한 사전 정보가 있는지 확인한다") {
+        val orderId = "orderId"
+        val amount = BigDecimal(1000)
+        beforeTest {
+            orderRepository.save(
+                Order(
+                    orderId = orderId,
+                    amount = amount
+                )
+            )
+        }
+        test("사전 정보와 일치한지 검증한다.") {
+            assertDoesNotThrow {
+                orderValidator.checkOrderValid(
+                    OrderDataRequest(
+                        orderId = orderId,
+                        amount = amount
+                    )
+                )
+            }
+        }
+
+        test("orderId 에 해당하는 값이 없으면 예외를 발생한다.") {
+            val exception = shouldThrow<PurchaseException> {
+                orderValidator.checkOrderValid(
+                    OrderDataRequest(
+                        orderId = "not Exist",
+                        amount = amount
+                    )
+                )
+            }
+            exception.purchaseExceptionCode shouldBe PurchaseExceptionCode.NOT_EXIST_ORDER_ID
+        }
+
+        test("Id 에 해당하는 금액이 다르면 예외를 발생한다.") {
+            val exception = shouldThrow<PurchaseException> {
+                orderValidator.checkOrderValid(
+                    OrderDataRequest(
+                        orderId = orderId,
+                        amount = BigDecimal(2000)
+                    )
+                )
+            }
+            exception.purchaseExceptionCode shouldBe PurchaseExceptionCode.NOT_VALID_ORDER_ID
+        }
+    }
+})

--- a/src/test/kotlin/purchase/domain/implementation/PurchaseValidatorTest.kt
+++ b/src/test/kotlin/purchase/domain/implementation/PurchaseValidatorTest.kt
@@ -10,51 +10,21 @@ import purchase.domain.PurchaseException
 import purchase.domain.PurchaseExceptionCode
 import purchase.domain.entity.Purchase
 import purchase.domain.entity.PurchaseInfo
-import purchase.domain.entity.PurchaseTemporary
-import purchase.domain.repository.PurchaseTemporaryRepository
+import purchase.domain.entity.Order
+import order.domain.repository.OrderRepository
 import purchase.domain.vo.PaymentMethod
 import purchase.domain.vo.PurchaseProvider
 import java.math.BigDecimal
 
-fun createPurchaseTemporary(orderId: String, amount: BigDecimal): PurchaseTemporary {
-    return PurchaseTemporary(orderId = orderId, amount = amount.setScale(0))
+fun createPurchaseTemporary(orderId: String, amount: BigDecimal): Order {
+    return Order(orderId = orderId, amount = amount.setScale(0))
 }
 
 @ImplementationTest
 class PurchaseValidatorTest(
     private val purchaseValidator: PurchaseValidator,
-    private val purchaseTemporaryRepository: PurchaseTemporaryRepository
 ) : FunSpec({
     extensions(listOf(SpringExtension))
-
-    context("주문에 대한 사전 정보가 있는지 확인한다") {
-        beforeTest {
-            purchaseTemporaryRepository.save(createPurchaseTemporary("orderId", BigDecimal(2000)))
-        }
-        test("사전 정보와 일치한지 검증한다.") {
-            shouldNotThrow<PurchaseException> {
-                purchaseValidator.checkOrderValid(
-                    OrderDataRequest("orderId", BigDecimal(2000)),
-                )
-            }
-        }
-
-        test("ORDER ID에 대한 주문이 없으면 예외를 발생한다.") {
-            shouldThrow<PurchaseException> {
-                purchaseValidator.checkOrderValid(
-                    OrderDataRequest("not-exist-orderId", BigDecimal(3000)),
-                )
-            }.purchaseExceptionCode() shouldBe PurchaseExceptionCode.NOT_EXIST_ORDER_ID
-        }
-
-        test("주문 금액과 ORDER ID가 동일하지 않으면 예외를 발생한다.") {
-            shouldThrow<PurchaseException> {
-                purchaseValidator.checkOrderValid(
-                    OrderDataRequest("orderId", BigDecimal(3000)),
-                )
-            }.purchaseExceptionCode() shouldBe PurchaseExceptionCode.NOT_VALID_ORDER_ID
-        }
-    }
     context("취소 주문에 대한 상태를 검증한다") {
         test("이미 취소된 상태라면 예외를 발생한다") {
             shouldThrow<PurchaseException> {

--- a/src/test/resources/acceptance/lottoCancel.json
+++ b/src/test/resources/acceptance/lottoCancel.json
@@ -32,7 +32,6 @@
       "id": 1,
       "lotto_round_info_id": 1,
       "issued_at": "now()",
-      "issued_lottoes_status": "MANUAL",
       "canceled": false
     }
   ],

--- a/src/test/resources/acceptance/lottoCancel.json
+++ b/src/test/resources/acceptance/lottoCancel.json
@@ -43,7 +43,7 @@
       "lotto_publish_id": 1
     }
   ],
-  "purchase_temporary": [
+  "orders": [
     {
       "order_id": "order-random-id-1",
       "amount": 1000

--- a/src/test/resources/acceptance/lottoOrder.json
+++ b/src/test/resources/acceptance/lottoOrder.json
@@ -1,0 +1,19 @@
+{
+  "lotto_round_info": [
+    {
+      "id": 1,
+      "round": 1034,
+      "start_date": "2025-01-18T10:00:00",
+      "end_date": "2025-02-20T20:00:00",
+      "draw_date": "2025-02-24T21:00:00",
+      "payment_deadline": "2026-01-16T23:59:59",
+      "status": "ONGOING"
+    }
+  ],
+  "lotto": [
+    {
+      "id": 1,
+      "numbers": "1,10,11,14,15,17"
+    }
+  ]
+}

--- a/src/test/resources/acceptance/lottoPurchase.json
+++ b/src/test/resources/acceptance/lottoPurchase.json
@@ -10,6 +10,27 @@
       "status": "ONGOING"
     }
   ],
+  "lotto_publish": [
+    {
+      "id": 1,
+      "lotto_round_info_id": 1,
+      "issued_at": "2025-01-19T10:00:00",
+      "issued_lottoes_status":"MANUAL",
+      "canceled": false
+    }
+  ],
+  "lotto": [
+    {
+      "id": 1,
+      "numbers": "1,10,11,14,15,17"
+    }
+  ],
+  "lotto_publish_lotto": [
+    {
+      "lotto_id": 1,
+      "lotto_publish_id": 1
+    }
+  ],
   "purchase": [
     {
       "id": "dfb3ad82-e2ba-4220-a969-0b4a293c9a8b",
@@ -28,7 +49,7 @@
     }
   ],
 
-  "purchase_temporary": [
+  "orders": [
     {
       "_comment": "정상적으로 처리될 결제",
       "order_id": "order-id-1",

--- a/src/test/resources/acceptance/lottoPurchase.json
+++ b/src/test/resources/acceptance/lottoPurchase.json
@@ -15,7 +15,6 @@
       "id": 1,
       "lotto_round_info_id": 1,
       "issued_at": "2025-01-19T10:00:00",
-      "issued_lottoes_status":"MANUAL",
       "canceled": false
     }
   ],
@@ -25,10 +24,11 @@
       "numbers": "1,10,11,14,15,17"
     }
   ],
-  "lotto_publish_lotto": [
+  "published_lotto": [
     {
       "lotto_id": 1,
-      "lotto_publish_id": 1
+      "lotto_publish_id": 1,
+      "status": "MANUAL"
     }
   ],
   "purchase": [
@@ -43,12 +43,11 @@
   ],
   "purchase_info": [
     {
-      "id":"b4386e47-8555-437c-bcd9-164262a9a3ba",
-      "total_amount":1000,
+      "id": "b4386e47-8555-437c-bcd9-164262a9a3ba",
+      "total_amount": 1000,
       "method": "CARD"
     }
   ],
-
   "orders": [
     {
       "_comment": "정상적으로 처리될 결제",

--- a/src/test/resources/clear.sql
+++ b/src/test/resources/clear.sql
@@ -1,7 +1,7 @@
 SET FOREIGN_KEY_CHECKS = 0;
 DELETE FROM lotto;
 DELETE FROM lotto_round_info;
-DELETE FROM purchase_temporary;
+DELETE FROM orders;
 DELETE FROM purchase;
 DELETE FROM purchase_info;
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
결제를 실행하기 전 `orderId` 를 미리 저장해서 웹 단에서 임의 orderId 를 통해 공격하거나, 조작할 수 있는 위험을 방지합니다.

주문 데이터를 저장하며 로또도 미리 발행합니다.
아래의 맥락에서 변경을 결정했습니다.

- 결제 시 발행을 생성하면, 웹 단에서 결제가 완료될 때 까지 시간으로 인해 ( 7시 59분 결제 진행을 해도, 8시가 지나면 마감이 되서 실패한다 )
( 차후 처리량 제한을 해결하기 위해서도 `결제대기` 상태가 필요하기에 이가 맞다고 생각한다. - [의견](https://github.com/youngsu5582/lotto/issues/3#issuecomment-2623787547) Thanks to 초코칩 )
- 결제 후, 외부 API 호출 시간으로도 시간이 소요되는데 로또 발행 및 조회 하는 시간을 줄인다.
- 주문이 생성되었는데, 같이 생성된 아무런 요소가 없는게 논리적으로 이상하다.

프론트단은 해당 PR 을 끝내고 추가 변경할 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
  - 로또 주문 처리를 위한 신규 주문 서비스 및 저장 기능 추가로, 주문 접수 및 결제 승인이 개선되었습니다.
  - 수동 로또 번호 선택 방식을 도입하여 종이 생성 및 가격 산정 과정이 보다 명확해졌습니다.
  - 새로운 주문 검증 및 고유 주문 ID 생성 로직이 추가되어 거래의 안정성과 신뢰성이 향상되었습니다.
  - 크로스 오리진 설정 개선으로 클라이언트와의 통합이 원활하게 진행됩니다.
  - 로또 라운드 및 티켓 정보를 포함한 새로운 JSON 구조가 추가되었습니다.
  - 새로운 로또 주문 데이터 전송 객체 및 응답 객체가 추가되었습니다.
  - 로또 발행 및 관리 관련 새로운 데이터 구조와 API가 도입되었습니다.

- **개선 사항**
  - 로또 구매 및 주문 처리 관련 API의 요청 구조가 간소화되었습니다.
  - 테스트 프레임워크가 강화되어 주문 처리 및 검증 로직의 신뢰성이 높아졌습니다.
  - 기존의 구매 임시 데이터 구조가 주문 데이터 구조로 변경되었습니다.
  - 주문 검증 로직이 개선되어 유효하지 않은 주문에 대한 예외 처리가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->