### PR TITLE
feat: 회원가입, 로그인 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,11 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")
 
+    // 토큰
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
     // Test 및 REST Docs 의존성
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.junit.vintage") // JUnit 5 전용
@@ -76,7 +81,7 @@ tasks.test {
 
 tasks.register<Test>("restDocsTest") {
     useJUnitPlatform {
-        includeTags("AcceptanceTest") // 특정 태그만 포함
+        includeTags("AcceptanceTest")
     }
 
     systemProperty("org.springframework.restdocs.outputDir", file("build/generated-snippets"))

--- a/frontend/config/index.ts
+++ b/frontend/config/index.ts
@@ -1,5 +1,5 @@
 export const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
-export const TOSS_CLIENT_KEY = process.env.NEXT_PUBLIC_TOSS_CLIENT_KEY;
-if (!TOSS_CLIENT_KEY) {
+export const TOSS_CLIENT_KEY = process.env.NEXT_PUBLIC_TOSS_CLIENT_KEY||'';
+if (TOSS_CLIENT_KEY.length==0) {
   throw new Error('NEXT_PUBLIC_TOSS_CLIENT_KEY 환경 변수가 설정되지 않았습니다.');
 }

--- a/frontend/services/factory.ts
+++ b/frontend/services/factory.ts
@@ -12,9 +12,9 @@ interface Services {
     payment: PaymentApiService | PaymentMockService;
 }
 
-const isMockAuth = process.env.NEXT_PUBLIC_MOCK_AUTH === 'true';
-const isMockPayment = process.env.NEXT_PUBLIC_MOCK_PAYMENT === 'true';
-const isMockTicket = process.env.NEXT_PUBLIC_MOCK_TICKET === 'true';
+const isMockAuth = process.env.NEXT_PUBLIC_MOCK_AUTH === 'true' || false;
+const isMockPayment = process.env.NEXT_PUBLIC_MOCK_PAYMENT === 'true' || false;
+const isMockTicket = process.env.NEXT_PUBLIC_MOCK_TICKET === 'true' || false;
 
 export function createServices() : Services {
   return {

--- a/frontend/services/payment-api.ts
+++ b/frontend/services/payment-api.ts
@@ -10,19 +10,14 @@ export class PaymentApiService extends BaseApiService {
       paymentKey: string; 
       orderId: string; 
       amount: number;
-      purchaseType?: 'CARD' | 'TOSS_PAY';
+      lottoPublishId: number;
+      purchaseType?: 'CARD';
       currency?: 'KRW';
-    }, 
-    tickets: LottoTickets
+    }
   ) {
     // 결제 금액 검증
     if (params.amount <= 0) {
       throw new Error('결제 금액은 0보다 커야 합니다.');
-    }
-
-    const expectedAmount = tickets.length * this.TICKET_PRICE;
-    if (params.amount !== expectedAmount) {
-      throw new Error(`결제 금액이 올바르지 않습니다. 예상 금액: ${expectedAmount}원, 실제 금액: ${params.amount}원`);
     }
 
     const requestBody: LottoPurchaseRequest = {
@@ -33,9 +28,7 @@ export class PaymentApiService extends BaseApiService {
         paymentKey: params.paymentKey,
         orderId: params.orderId,
       },
-      lottoRequest: {
-        numbers: tickets,
-      },
+      lottoPublishId: params.lottoPublishId
     };
 
     return this.fetchJson('/api/tickets', {
@@ -45,7 +38,7 @@ export class PaymentApiService extends BaseApiService {
   }
 
   async createTemporaryOrder(data: OrderDataRequest): Promise<OrderDataResponse> {
-    return this.fetchJson('/api/orders/temporary', {
+    return this.fetchJson('/api/orders', {
       method: 'POST',
       body: JSON.stringify(data),
     });

--- a/frontend/types/payment.ts
+++ b/frontend/types/payment.ts
@@ -1,23 +1,24 @@
 export interface LottoPurchaseRequest {
   purchaseHttpRequest: {
-    purchaseType: 'CARD' | 'TOSS_PAY';
+    purchaseType: 'CARD';
     currency: 'KRW';
     amount: number;
     paymentKey: string;
     orderId: string;
   };
-  lottoRequest: {
-    numbers: number[][];
-  };
+  lottoPublishId: number;
 }
 
 export interface OrderDataRequest {
-  orderId: string;
-  amount: number;
   numbers: number[][];
 }
 
 export interface OrderDataResponse {
   success: boolean;
-  message?: string;
+  status: number;
+  message: string;
+  data: {
+    lottoPublishId: number;
+    orderId: string;
+  };
 } 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -75,3 +75,48 @@ include::{snippets}/cancel-success/response-fields.adoc[]
 include::{snippets}/cancel-failure/http-request.adoc[]
 include::{snippets}/cancel-failure/http-response.adoc[]
 include::{snippets}/cancel-failure/response-fields.adoc[]
+
+== 멤버 로그인
+=== 멤버 로그인 성공
+이메일과 비밀번호가 일치하면 로그인에 성공해 토큰을 반환한다.
+
+include::{snippets}/login-success/http-request.adoc[]
+include::{snippets}/login-success/http-response.adoc[]
+include::{snippets}/login-success/request-fields.adoc[]
+include::{snippets}/login-success/response-fields.adoc[]
+
+=== 멤버 로그인 실패
+아래와 같은 경우 로그인에 실패한다.
+
+==== 이메일에 해당하는 멤버 미존재
+존재하지 않는 이메일로 로그인 시도시 실패한다.
+
+include::{snippets}/login-fail-not-exist-member/http-request.adoc[]
+include::{snippets}/login-fail-not-exist-member/http-response.adoc[]
+include::{snippets}/login-fail-not-exist-member/response-fields.adoc[]
+
+==== 비밀번호 불일치
+이메일에 해당하는 비밀번호가 불일치 하면 실패한다.
+
+include::{snippets}/login-fail-password/http-request.adoc[]
+include::{snippets}/login-fail-password/http-response.adoc[]
+include::{snippets}/login-fail-password/response-fields.adoc[]
+
+== 멤버 회원가입
+=== 멤버 회원가입 성공
+이메일과 비밀번호로 회원가입을 한다.
+
+include::{snippets}/register-success/http-request.adoc[]
+include::{snippets}/register-success/http-response.adoc[]
+include::{snippets}/register-success/request-fields.adoc[]
+include::{snippets}/register-success/response-fields.adoc[]
+
+=== 멤버 회원가입 실패
+아래와 같은 경우 회원가입에 실패한다.
+
+==== 이미 존재하는 이메일
+
+include::{snippets}/register-fail-exist-email/http-request.adoc[]
+include::{snippets}/register-fail-exist-email/http-response.adoc[]
+include::{snippets}/register-fail-exist-email/request-fields.adoc[]
+include::{snippets}/register-fail-exist-email/response-fields.adoc[]

--- a/src/main/kotlin/app/LottoApplication.kt
+++ b/src/main/kotlin/app/LottoApplication.kt
@@ -5,9 +5,9 @@ import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
-@SpringBootApplication(scanBasePackages = ["lotto", "purchase", "order","toss", "common"])
-@EntityScan(basePackages = ["lotto", "purchase", "order"])
-@EnableJpaRepositories(basePackages = ["lotto", "purchase", "order"])
+@SpringBootApplication(scanBasePackages = ["lotto", "purchase", "order","toss", "common","member"])
+@EntityScan(basePackages = ["lotto", "purchase", "order","member"])
+@EnableJpaRepositories(basePackages = ["lotto", "purchase", "order","member"])
 class LottoApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/common/dto/ApiResponseBuilder.kt
+++ b/src/main/kotlin/common/dto/ApiResponseBuilder.kt
@@ -1,0 +1,51 @@
+package common.dto
+
+/**
+ * ApiResponse를 DSL 형식으로 만들기 위한 함수
+ *
+ * 사용 예:
+ * val response = apiResponse<String> {
+ *     success = false
+ *     status = 404
+ *     message = "Not Found"
+ *     data = null
+ *     header("X-Error-Code", "1234")
+ *     headers {
+ *         put("X-Another-Header", "value")
+ *     }
+ * }
+ */
+fun <T> apiResponse(block: ApiResponseDsl<T>.() -> Unit): ApiResponse<T> =
+    ApiResponseDsl<T>().apply(block).build()
+
+class ApiResponseDsl<T> {
+    var success: Boolean = true
+    var status: Int = 200
+    var message: String? = "ok"
+    var data: T? = null
+
+    private val _headers: MutableMap<String, String> = mutableMapOf()
+
+    /**
+     * 단일 헤더 추가용 함수
+     */
+    fun header(key: String, value: String) {
+        _headers[key] = value
+    }
+
+    /**
+     * 복수 헤더 설정용 함수
+     */
+    fun headers(block: MutableMap<String, String>.() -> Unit) {
+        _headers.apply(block)
+    }
+
+    fun build(): ApiResponse<T> =
+        ApiResponse(
+            success = success,
+            status = status,
+            message = message,
+            data = data,
+            headers = _headers.toMap()
+        )
+}

--- a/src/main/kotlin/lotto/controller/ExceptionResponseHandler.kt
+++ b/src/main/kotlin/lotto/controller/ExceptionResponseHandler.kt
@@ -5,7 +5,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import purchase.domain.PurchaseException
-import kotlin.math.log
 
 private val logger = KotlinLogging.logger {}
 
@@ -21,6 +20,12 @@ class ExceptionResponseHandler {
 
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalException(ex: IllegalArgumentException): ApiResponse<Void> {
+        logger.warn { ex.stackTraceToString() }
+        return ApiResponse.fail(message = ex.message)
+    }
+
+    @ExceptionHandler(NoSuchElementException::class)
+    fun handleNoSuchElementException(ex: NoSuchElementException): ApiResponse<Void> {
         logger.warn { ex.stackTraceToString() }
         return ApiResponse.fail(message = ex.message)
     }

--- a/src/main/kotlin/member/config/TokenConfig.kt
+++ b/src/main/kotlin/member/config/TokenConfig.kt
@@ -1,0 +1,14 @@
+package member.config
+
+import io.jsonwebtoken.Clock
+import io.jsonwebtoken.impl.DefaultClock
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class TokenConfig {
+    @Bean
+    fun tokenClock(): Clock {
+        return DefaultClock.INSTANCE
+    }
+}

--- a/src/main/kotlin/member/config/TokenProperties.kt
+++ b/src/main/kotlin/member/config/TokenProperties.kt
@@ -1,0 +1,12 @@
+package member.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "jwt")
+data class TokenProperties(
+    var secret: String = "",
+    var accessTokenExpiry: Long = 0L,
+) {
+}

--- a/src/main/kotlin/member/controller/LocalLoginHttpRequest.kt
+++ b/src/main/kotlin/member/controller/LocalLoginHttpRequest.kt
@@ -1,0 +1,15 @@
+package member.controller
+
+import member.domain.vo.MemberIdentifier
+
+data class LocalLoginHttpRequest(
+    val email: String,
+    val password: String
+) {
+    fun toIdentifier(): MemberIdentifier {
+        return MemberIdentifier(
+            email = email,
+            password = password
+        )
+    }
+}

--- a/src/main/kotlin/member/controller/LocalLoginHttpResponse.kt
+++ b/src/main/kotlin/member/controller/LocalLoginHttpResponse.kt
@@ -1,0 +1,5 @@
+package member.controller
+
+data class LocalLoginHttpResponse(
+    val accessToken: String
+)

--- a/src/main/kotlin/member/controller/LocalRegisterHttpRequest.kt
+++ b/src/main/kotlin/member/controller/LocalRegisterHttpRequest.kt
@@ -1,0 +1,17 @@
+package member.controller
+
+import member.domain.vo.MemberIdentifier
+
+data class LocalRegisterHttpRequest(
+    val email: String,
+    val password: String
+) {
+    fun toIdentifier(): MemberIdentifier {
+        return MemberIdentifier(
+            email = email,
+            password = password
+        )
+    }
+}
+
+

--- a/src/main/kotlin/member/controller/LocalRegisterHttpResponse.kt
+++ b/src/main/kotlin/member/controller/LocalRegisterHttpResponse.kt
@@ -1,0 +1,8 @@
+package member.controller
+
+import java.util.UUID
+
+class LocalRegisterHttpResponse(
+    val id:UUID,
+) {
+}

--- a/src/main/kotlin/member/controller/MemberController.kt
+++ b/src/main/kotlin/member/controller/MemberController.kt
@@ -1,0 +1,34 @@
+package member.controller
+
+import common.dto.ApiResponse
+import common.dto.apiResponse
+import common.web.Body
+import common.web.HttpController
+import common.web.Post
+import member.service.MemberService
+import member.service.TokenService
+
+@HttpController
+class MemberController(
+    private val memberService: MemberService,
+    private val tokenService: TokenService
+) {
+    @Post("/api/auth/login")
+    fun login(@Body localLoginHttpRequest: LocalLoginHttpRequest): ApiResponse<LocalLoginHttpResponse> {
+        val memberData = memberService.readMember(localLoginHttpRequest.toIdentifier())
+        val token = tokenService.createToken(memberData.id)
+        return apiResponse {
+            data = LocalLoginHttpResponse(accessToken = token.accessToken)
+        }
+    }
+
+    @Post("/api/auth/register")
+    fun register(@Body localRegisterHttpRequest: LocalRegisterHttpRequest): ApiResponse<LocalRegisterHttpResponse> {
+        val memberData = memberService.registerMember(localRegisterHttpRequest.toIdentifier())
+        return apiResponse {
+            data = LocalRegisterHttpResponse(id = memberData.id)
+            message = "회원가입이 완료되었습니다"
+            status = 201
+        }
+    }
+}

--- a/src/main/kotlin/member/domain/entity/Member.kt
+++ b/src/main/kotlin/member/domain/entity/Member.kt
@@ -1,0 +1,25 @@
+package member.domain.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.*
+
+@Entity
+@Table(name = "members")
+class Member(
+    @Id
+    @GeneratedValue(generator = "UUID")
+    private val id: UUID? = null,
+    private val email: String,
+    private val password: String
+) {
+    fun isNotEqualPassword(password: String): Boolean {
+        return this.password != password
+    }
+
+    fun getId() = id ?: throw IllegalArgumentException("Not Exist Id")
+    fun getEmail() = email
+    fun getPassword() = password
+}

--- a/src/main/kotlin/member/domain/implementation/MemberReader.kt
+++ b/src/main/kotlin/member/domain/implementation/MemberReader.kt
@@ -1,0 +1,22 @@
+package member.domain.implementation
+
+import common.business.Implementation
+import member.domain.entity.Member
+import member.domain.repository.MemberRepository
+import member.domain.vo.MemberIdentifier
+
+@Implementation
+class MemberReader(
+    private val memberRepository: MemberRepository
+) {
+    fun findMember(memberIdentifier: MemberIdentifier): Member =
+        (memberRepository.findByEmail(memberIdentifier.email)
+            ?: throw NoSuchElementException("Member not found with email: ${memberIdentifier.email}"))
+            .also {
+                if (it.isNotEqualPassword(memberIdentifier.password)) {
+                    throw IllegalArgumentException("Not Equal Password")
+                }
+            }
+
+    fun existByEmail(email: String) = memberRepository.findByEmail(email) != null
+}

--- a/src/main/kotlin/member/domain/implementation/MemberWriter.kt
+++ b/src/main/kotlin/member/domain/implementation/MemberWriter.kt
@@ -1,0 +1,27 @@
+package member.domain.implementation
+
+import common.business.Implementation
+import common.business.Transaction
+import common.business.Write
+import member.domain.entity.Member
+import member.domain.repository.MemberRepository
+import member.domain.vo.MemberIdentifier
+
+@Implementation
+class MemberWriter(
+    private val memberReader: MemberReader,
+    private val memberRepository: MemberRepository
+) {
+    @Transaction
+    @Write
+    fun saveMember(memberIdentifier: MemberIdentifier): Member =
+        require(!memberReader.existByEmail(memberIdentifier.email)) { "Already Exist Email" }
+            .run {
+                memberRepository.save(
+                    Member(
+                        email = memberIdentifier.email,
+                        password = memberIdentifier.password
+                    )
+                )
+            }
+}

--- a/src/main/kotlin/member/domain/implementation/TimeProvider.kt
+++ b/src/main/kotlin/member/domain/implementation/TimeProvider.kt
@@ -1,0 +1,11 @@
+package member.domain.implementation
+
+import common.business.Implementation
+import java.util.*
+
+@Implementation
+class TimeProvider {
+    fun now(): Date {
+        return Date()
+    }
+}

--- a/src/main/kotlin/member/domain/implementation/TokenGenerator.kt
+++ b/src/main/kotlin/member/domain/implementation/TokenGenerator.kt
@@ -1,0 +1,44 @@
+package member.domain.implementation
+
+import common.business.Implementation
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Clock
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
+import member.config.TokenProperties
+import java.util.*
+import javax.crypto.SecretKey
+
+@Implementation
+class TokenGenerator(
+    jwtProperties: TokenProperties,
+    private val clock: Clock
+) {
+    private val key: SecretKey = Keys.hmacShaKeyFor(jwtProperties.secret.encodeToByteArray())
+    private val accessTokenExpire: Long = jwtProperties.accessTokenExpiry
+
+    fun generateAccessToken(value: String): String {
+        val now = clock.now()
+        val validity = Date(now.time.plus(accessTokenExpire))
+
+        return Jwts.builder()
+            .setSubject(value)
+            .setIssuedAt(now)
+            .setExpiration(validity)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact()
+    }
+
+    fun decodeToken(token: String): Claims {
+        return try {
+            Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .body
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Invalid token: ${e.message}")
+        }
+    }
+}

--- a/src/main/kotlin/member/domain/repository/MemberRepository.kt
+++ b/src/main/kotlin/member/domain/repository/MemberRepository.kt
@@ -1,0 +1,9 @@
+package member.domain.repository
+
+import member.domain.entity.Member
+import org.springframework.data.repository.CrudRepository
+import java.util.*
+
+interface MemberRepository : CrudRepository<Member, UUID> {
+    fun findByEmail(email: String): Member?
+}

--- a/src/main/kotlin/member/domain/vo/MemberIdentifier.kt
+++ b/src/main/kotlin/member/domain/vo/MemberIdentifier.kt
@@ -1,0 +1,6 @@
+package member.domain.vo
+
+data class MemberIdentifier(
+    val email: String,
+    val password: String
+)

--- a/src/main/kotlin/member/domain/vo/Token.kt
+++ b/src/main/kotlin/member/domain/vo/Token.kt
@@ -1,0 +1,6 @@
+package member.domain.vo
+
+data class Token(
+    val accessToken: String
+) {
+}

--- a/src/main/kotlin/member/service/MemberService.kt
+++ b/src/main/kotlin/member/service/MemberService.kt
@@ -1,0 +1,19 @@
+package member.service
+
+import common.business.BusinessService
+import member.domain.implementation.MemberReader
+import member.domain.implementation.MemberWriter
+import member.domain.vo.MemberIdentifier
+import member.service.dto.MemberData
+
+@BusinessService
+class MemberService(
+    private val memberReader: MemberReader,
+    private val memberWriter: MemberWriter
+) {
+    fun registerMember(memberIdentifier: MemberIdentifier): MemberData =
+        MemberData.from(memberWriter.saveMember(memberIdentifier))
+
+    fun readMember(memberIdentifier: MemberIdentifier): MemberData =
+        MemberData.from(memberReader.findMember(memberIdentifier))
+}

--- a/src/main/kotlin/member/service/TokenService.kt
+++ b/src/main/kotlin/member/service/TokenService.kt
@@ -1,0 +1,15 @@
+package member.service
+
+import common.business.BusinessService
+import member.domain.implementation.TokenGenerator
+import member.domain.vo.Token
+import java.util.*
+
+@BusinessService
+class TokenService(
+    private val tokenGenerator: TokenGenerator
+) {
+    fun createToken(id: UUID): Token {
+        return Token(tokenGenerator.generateAccessToken(id.toString()))
+    }
+}

--- a/src/main/kotlin/member/service/dto/MemberData.kt
+++ b/src/main/kotlin/member/service/dto/MemberData.kt
@@ -1,0 +1,20 @@
+package member.service.dto
+
+import member.domain.entity.Member
+import java.util.*
+
+data class MemberData(
+    val id: UUID,
+    val email: String,
+    val password: String
+) {
+    companion object {
+        fun from(member: Member): MemberData {
+            return MemberData(
+                id = member.getId(),
+                email = member.getEmail(),
+                password = member.getPassword()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/order/domain/entity/Order.kt
+++ b/src/main/kotlin/order/domain/entity/Order.kt
@@ -1,4 +1,4 @@
-package purchase.domain.entity
+package order.domain.entity
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity

--- a/src/main/kotlin/order/domain/implementation/OrderProcessor.kt
+++ b/src/main/kotlin/order/domain/implementation/OrderProcessor.kt
@@ -4,7 +4,7 @@ import common.business.Implementation
 import common.business.Transaction
 import common.business.Write
 import order.domain.vo.OrderRequest
-import purchase.domain.entity.Order
+import order.domain.entity.Order
 import order.domain.repository.OrderRepository
 
 @Implementation

--- a/src/main/kotlin/order/domain/repository/OrderRepository.kt
+++ b/src/main/kotlin/order/domain/repository/OrderRepository.kt
@@ -1,7 +1,7 @@
 package order.domain.repository
 
 import org.springframework.data.repository.CrudRepository
-import purchase.domain.entity.Order
+import order.domain.entity.Order
 import java.util.*
 
 interface OrderRepository : CrudRepository<Order, UUID> {

--- a/src/main/kotlin/order/domain/vo/OrderData.kt
+++ b/src/main/kotlin/order/domain/vo/OrderData.kt
@@ -1,6 +1,6 @@
 package order.domain.vo
 
-import purchase.domain.entity.Order
+import order.domain.entity.Order
 import java.math.BigDecimal
 
 class OrderData(

--- a/src/test/kotlin/config/AcceptanceTestExecutionListener.kt
+++ b/src/test/kotlin/config/AcceptanceTestExecutionListener.kt
@@ -19,6 +19,7 @@ import org.springframework.test.context.support.AbstractTestExecutionListener
 import org.springframework.util.StreamUtils
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
+import java.util.UUID
 
 class AcceptanceTestExecutionListener : AbstractTestExecutionListener() {
 
@@ -100,6 +101,7 @@ class AcceptanceTestExecutionListener : AbstractTestExecutionListener() {
         return when {
             value == null -> "NULL"
             value is String && value.lowercase() == "now()" -> "now()"
+            value is String && value.lowercase() == "uuid()" -> "'${UUID.randomUUID()}'"
             else -> "'$value'"
         }
     }

--- a/src/test/kotlin/lotto/service/LottoPurchaseServiceTest.kt
+++ b/src/test/kotlin/lotto/service/LottoPurchaseServiceTest.kt
@@ -5,7 +5,6 @@ import config.ImplementationTest
 import lotto.domain.entity.*
 import lotto.domain.repository.LottoBillRepository
 import lotto.domain.repository.LottoPublishRepository
-import lotto.domain.repository.LottoRepository
 import lotto.domain.repository.LottoRoundInfoRepository
 import lotto.domain.vo.Currency
 import lotto.domain.vo.LottoPurchaseRequest
@@ -17,7 +16,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
-import purchase.domain.entity.Order
+import order.domain.entity.Order
 import purchase.domain.entity.Purchase
 import purchase.domain.entity.PurchaseInfo
 import purchase.domain.repository.PurchaseRepository

--- a/src/test/kotlin/member/controller/MemberLoginTest.kt
+++ b/src/test/kotlin/member/controller/MemberLoginTest.kt
@@ -1,0 +1,86 @@
+package member.controller
+
+import config.AcceptanceTest
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.*
+import sendRequest
+import kotlin.test.Test
+
+@AcceptanceTest(["/acceptance/member.json"])
+class MemberLoginTest {
+    @Test
+    fun `로그인을 해 토큰을 받는다`() {
+        val request = createRequest(
+            email = "joyson5582@gmail.com",
+            password = "password1234"
+        )
+        sendRequest(
+            request,
+            "login-success",
+            commonRequestFields(),
+            successResponseFields(),
+            200,
+            "/api/auth/login"
+        )
+    }
+
+    @Test
+    fun `멤버가 없으면 예외가 발생한다`() {
+        val request = createRequest(
+            email = "notExist@gmail.com",
+            password = "password1234"
+        )
+        sendRequest(
+            request,
+            "login-fail-not-exist-member",
+            commonRequestFields(),
+            errorResponseFields(),
+            400,
+            "/api/auth/login"
+        )
+    }
+
+    @Test
+    fun `비밀번호가 틀리면 예외가 발생한다`() {
+        val request = createRequest(
+            email = "notExist@gmail.com",
+            password = "notEqualPassword"
+        )
+        sendRequest(
+            request,
+            "login-fail-password",
+            commonRequestFields(),
+            errorResponseFields(),
+            400,
+            "/api/auth/login"
+        )
+    }
+
+    private fun createRequest(
+        email: String,
+        password: String
+    ): Map<String, Any> {
+        return mapOf(
+            "email" to email,
+            "password" to password
+        )
+    }
+
+    private fun commonRequestFields() = requestFields(
+        fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+        fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
+    )
+
+    private fun successResponseFields() = responseFields(
+        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+        fieldWithPath("status").type(JsonFieldType.NUMBER).description("응답 상태"),
+        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+        fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("생성된 액세스 토큰"),
+    )
+
+    private fun errorResponseFields() = responseFields(
+        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+        fieldWithPath("status").type(JsonFieldType.NUMBER).description("응답 상태"),
+        fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지")
+    )
+}

--- a/src/test/kotlin/member/controller/MemberRegisterTest.kt
+++ b/src/test/kotlin/member/controller/MemberRegisterTest.kt
@@ -1,0 +1,70 @@
+package member.controller
+
+import config.AcceptanceTest
+import org.junit.jupiter.api.Test
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.*
+import sendRequest
+
+@AcceptanceTest(["/acceptance/member.json"])
+class MemberRegisterTest {
+    @Test
+    fun `새로운 멤버가 회원가입을 한다`() {
+        val request = createRequest(
+            email = "newMember@gmail.com",
+            password = "password1234"
+        )
+        sendRequest(
+            request,
+            "register-success",
+            commonRequestFields(),
+            successResponseFields(),
+            201,
+            "/api/auth/register"
+        )
+    }
+
+    @Test
+    fun `기존에 있는 이메일로 회원가입시 실패한다`() {
+        val request = createRequest(
+            email = "joyson5582@gmail.com",
+            password = "password1234"
+        )
+        sendRequest(
+            request,
+            "register-fail-exist-email",
+            commonRequestFields(),
+            errorResponseFields(),
+            400,
+            "/api/auth/register"
+        )
+    }
+
+    private fun createRequest(
+        email: String,
+        password: String
+    ): Map<String, Any> {
+        return mapOf(
+            "email" to email,
+            "password" to password
+        )
+    }
+
+    private fun commonRequestFields() = requestFields(
+        fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+        fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
+    )
+
+    private fun successResponseFields() = responseFields(
+        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+        fieldWithPath("status").type(JsonFieldType.NUMBER).description("응답 상태"),
+        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+        fieldWithPath("data.id").type(JsonFieldType.STRING).description("생성된 멤버 ID"),
+    )
+
+    private fun errorResponseFields() = responseFields(
+        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+        fieldWithPath("status").type(JsonFieldType.NUMBER).description("응답 상태"),
+        fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지")
+    )
+}

--- a/src/test/kotlin/member/domain/implementation/TokenGeneratorTest.kt
+++ b/src/test/kotlin/member/domain/implementation/TokenGeneratorTest.kt
@@ -1,0 +1,45 @@
+package member.domain.implementation
+
+import io.jsonwebtoken.Clock
+import io.jsonwebtoken.impl.FixedClock
+import io.kotest.assertions.print.print
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import member.config.TokenProperties
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import java.util.*
+
+class TokenGeneratorTest : FunSpec({
+
+    context("토큰은 대칭키로 인코딩과 디코딩시 동일하다") {
+        val tokenGenerator = createTokenGenerator()
+
+        val value = "sample"
+        val token = tokenGenerator.generateAccessToken(value)
+        tokenGenerator.decodeToken(token).subject shouldBe value
+    }
+    // Jwts 자체 Clock 은 건들수가 없다.
+    // parseClaimsJws(token) 로직 내부에서 DefaultCLock 을 활용한다
+    // 우리는 단지, 토큰 생성을 하는 시간만 정할 수 있다.
+    context("유효기간과 현재 시간이 동일하면 예외가 발생한다") {
+
+        val now = Date.from(Instant.now())
+        val clock = FixedClock(now)
+        val tokenGenerator = createTokenGenerator(expire = 10, clock = clock)
+
+        val token = tokenGenerator.generateAccessToken("sample")
+        assertThrows<IllegalArgumentException> {
+            tokenGenerator.decodeToken(token)
+        }
+    }
+})
+
+private fun createTokenGenerator(expire: Long = 160000, clock: Clock = FixedClock()) =
+    TokenGenerator(
+        TokenProperties(
+            secret = "secretKeyNeedMustOver256bitsAndThisKeyBitsOver256bits",
+            accessTokenExpiry = expire,
+        ),
+        clock = clock
+    )

--- a/src/test/kotlin/order/domain/implementation/OrderValidatorTest.kt
+++ b/src/test/kotlin/order/domain/implementation/OrderValidatorTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.springframework.context.annotation.Import
 import purchase.domain.PurchaseException
 import purchase.domain.PurchaseExceptionCode
-import purchase.domain.entity.Order
+import order.domain.entity.Order
 import java.math.BigDecimal
 
 @ImplementationTest

--- a/src/test/resources/acceptance/member.json
+++ b/src/test/resources/acceptance/member.json
@@ -1,0 +1,9 @@
+{
+  "members": [
+    {
+      "id": "uuid()",
+      "email": "joyson5582@gmail.com",
+      "password": "password1234"
+    }
+  ]
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -21,4 +21,6 @@ toss:
     api-key: test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
     payment-url: /v1/payments/confirm
     cancel-url: /v1/payments/{paymentKey}/cancel
-
+jwt:
+  access-token-expiry: 16000000
+  secret: justkeyfortestkeyisThisKeyWithOverall256bits


### PR DESCRIPTION
단순 결제 로직을 학습하기 위한 프로젝트 이므로 `카카오 로그인`은 불필요하다 판단해
최대한 간단한 회원가입 / 로그인으로 구현했습니다.

차후, 프론트엔드 연결 및 현재 통합 테스트 부분의 비효율적 ( 공통 응답, 에러 응답 매번 처리 ) 리팩토링 할 예정입니다.