### PR TITLE
feat: 결제 승인/취소시 사용자 인증 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -23,6 +23,12 @@ include::{snippets}/purchase-ticket-success/request-fields.adoc[]
 include::{snippets}/purchase-ticket-success/response-fields.adoc[]
 
 === 로또 결제 실패
+
+==== 사용자 인증 실패
+`Authorization Bearer ...` 형식의 토큰이 아니면 실패한다.
+
+include::{snippets}/purchase-ticket-failure-not-authenticated/index.adoc[]
+
 ==== 결제 임시 데이터 미존재
 결제 임시 데이터가 없으면 실패한다.
 결제의 정합성을 보장하기 위해서 임시 데이터를 저장 후 프론트엔드에서 작업을 수행한다.
@@ -67,9 +73,18 @@ include::{snippets}/purchase-ticket-failure-purchase-provider-invalid/response-f
 include::{snippets}/cancel-success/http-request.adoc[]
 include::{snippets}/cancel-success/http-response.adoc[]
 include::{snippets}/cancel-success/request-fields.adoc[]
+include::{snippets}/cancel-success/request-headers.adoc[]
 include::{snippets}/cancel-success/response-fields.adoc[]
 
 === 로또 결제 취소 실패
+
+==== 사용자 인증 실패
+`Authorization Bearer ...` 형식의 토큰이 아니면 실패한다.
+
+include::{snippets}/purchase-ticket-failure-not-authenticated/index.adoc[]
+
+==== 영수증 미존재
+
 영수증이 존재하지 않으면 실패한다.
 
 include::{snippets}/cancel-failure/http-request.adoc[]

--- a/src/main/kotlin/auth/config/AuthExceptionHandler.kt
+++ b/src/main/kotlin/auth/config/AuthExceptionHandler.kt
@@ -1,0 +1,23 @@
+package auth.config
+
+import common.dto.ApiResponse
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.server.ResponseStatusException
+
+@ControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class AuthExceptionHandler {
+
+    @ExceptionHandler(ResponseStatusException::class)
+    fun handleResponseStatusException(ex: ResponseStatusException): ApiResponse<Any?> {
+        return ApiResponse(
+            success = false,
+            status = ex.statusCode.value(),
+            message = ex.reason ?: "에러가 발생했습니다.",
+            data = null
+        )
+    }
+}

--- a/src/main/kotlin/auth/config/AuthWebConfig.kt
+++ b/src/main/kotlin/auth/config/AuthWebConfig.kt
@@ -1,19 +1,19 @@
 package auth.config
 
-import org.springframework.context.annotation.Bean
+import auth.service.TokenService
+import member.service.MemberService
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-class WebMvcConfig : WebMvcConfigurer {
-
-    @Bean
-    fun accessTokenArgumentResolver(): AccessTokenArgumentResolver {
-        return AccessTokenArgumentResolver()
-    }
+class WebMvcConfig(
+    private val tokenService: TokenService,
+    private val memberService: MemberService
+) : WebMvcConfigurer {
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
-        resolvers.add(accessTokenArgumentResolver())
+        resolvers.add(AccessTokenArgumentResolver())
+        resolvers.add(AuthenticatedMemberArgumentResolver(tokenService, memberService))
     }
 }

--- a/src/main/kotlin/auth/config/AuthenticatedMemberArgumentResolver.kt
+++ b/src/main/kotlin/auth/config/AuthenticatedMemberArgumentResolver.kt
@@ -1,0 +1,55 @@
+package auth.config
+
+import auth.domain.vo.AccessToken
+import auth.domain.vo.AuthenticatedMember
+import auth.service.TokenService
+import member.service.MemberService
+import org.springframework.core.MethodParameter
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import org.springframework.web.server.ResponseStatusException
+
+
+class AuthenticatedMemberArgumentResolver(
+    private val tokenService: TokenService,
+    private val memberService: MemberService
+) : HandlerMethodArgumentResolver {
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.parameterType == AuthenticatedMember::class.java
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): Any {
+        val authorization = webRequest.getHeader(AUTHORIZATION)
+            ?: throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다.")
+
+        if (!authorization.startsWith(TOKEN_PREFIX)) {
+            throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "부적절한 토큰입니다.")
+        }
+
+        val token = authorization.substringAfter(TOKEN_PREFIX).trim()
+        try {
+            val memberId = tokenService.decodeToken(AccessToken(token))
+            val memberData = memberService.readMember(memberId)
+            return AuthenticatedMember(
+                id = memberData.id,
+                email = memberData.email
+            )
+        }catch (e:IllegalArgumentException){
+            throw ResponseStatusException(HttpStatus.UNAUTHORIZED,e.message,e)
+        }
+    }
+
+    companion object {
+        const val AUTHORIZATION = "Authorization"
+        const val TOKEN_PREFIX = "Bearer"
+    }
+}

--- a/src/main/kotlin/auth/domain/vo/Authenticated.kt
+++ b/src/main/kotlin/auth/domain/vo/Authenticated.kt
@@ -1,0 +1,5 @@
+package auth.domain.vo
+
+interface Authenticated {
+    val memberId: String
+}

--- a/src/main/kotlin/auth/domain/vo/AuthenticatedMember.kt
+++ b/src/main/kotlin/auth/domain/vo/AuthenticatedMember.kt
@@ -1,0 +1,9 @@
+package auth.domain.vo
+
+data class AuthenticatedMember(
+    val id: String,
+    val email: String
+) : Authenticated {
+    override val memberId: String
+        get() = id
+}

--- a/src/main/kotlin/auth/service/TokenService.kt
+++ b/src/main/kotlin/auth/service/TokenService.kt
@@ -10,8 +10,8 @@ import java.util.*
 class TokenService(
     private val tokenGenerator: TokenGenerator
 ) {
-    fun createToken(id: UUID): Token {
-        return Token(tokenGenerator.generateAccessToken(id.toString()))
+    fun createToken(id: String): Token {
+        return Token(tokenGenerator.generateAccessToken(id))
     }
 
     fun decodeToken(token: AccessToken): String {

--- a/src/main/kotlin/lotto/controller/ExceptionResponseHandler.kt
+++ b/src/main/kotlin/lotto/controller/ExceptionResponseHandler.kt
@@ -9,9 +9,7 @@ import purchase.domain.PurchaseException
 private val logger = KotlinLogging.logger {}
 
 @ControllerAdvice
-class ExceptionResponseHandler {
-    companion object
-
+class LottoExceptionHandler {
     @ExceptionHandler(PurchaseException::class)
     fun handlePurchaseException(ex: PurchaseException): ApiResponse<Void> {
         logger.warn { ex.stackTraceToString() }

--- a/src/main/kotlin/lotto/controller/LottoPurchaseController.kt
+++ b/src/main/kotlin/lotto/controller/LottoPurchaseController.kt
@@ -1,5 +1,6 @@
 package lotto.controller
 
+import auth.domain.vo.AuthenticatedMember
 import common.dto.ApiResponse
 import common.web.Body
 import common.web.HttpController
@@ -15,11 +16,13 @@ class LottoPurchaseController(
     @Post("/api/tickets")
     fun purchase(
         @Body lottoPurchaseHttpRequest: LottoPurchaseHttpRequest,
+        authenticatedMember: AuthenticatedMember
     ): ApiResponse<LottoPurchaseHttpResponse> {
         val lottoPurchaseData =
             lottoPurchaseService.purchase(
                 lottoPurchaseHttpRequest.toPurchaseRequest(),
-                lottoPurchaseHttpRequest.lottoPublishId
+                lottoPurchaseHttpRequest.lottoPublishId,
+                authenticatedMember
             )
         return ApiResponse.ok(
             data = LottoPurchaseHttpResponse.from(lottoPurchaseData)
@@ -28,11 +31,13 @@ class LottoPurchaseController(
 
     @Post("/api/cancel")
     fun cancel(
-        @Body lottoCancelHttpRequest: LottoCancelHttpRequest
+        @Body lottoCancelHttpRequest: LottoCancelHttpRequest,
+        authenticatedMember: AuthenticatedMember
     ): ApiResponse<LottoPurchaseHttpResponse> {
         val lottoPurchaseData =
             lottoPurchaseService.cancel(
-                lottoCancelHttpRequest.billId
+                lottoCancelHttpRequest.billId,
+                authenticatedMember
             )
         return ApiResponse.ok(
             data = LottoPurchaseHttpResponse.from(lottoPurchaseData)

--- a/src/main/kotlin/lotto/domain/entity/LottoBill.kt
+++ b/src/main/kotlin/lotto/domain/entity/LottoBill.kt
@@ -17,8 +17,10 @@ class LottoBill(
     private val purchase: Purchase,
     @OneToOne
     private val lottoPublish: LottoPublish,
-){
+    private val memberId:String
+) {
     fun getId() = id
     fun getPurchase() = purchase
     fun getLottoPublish() = lottoPublish
+    fun isOwner(memberId: String) = this.memberId ==memberId
 }

--- a/src/main/kotlin/lotto/domain/implementation/LottoReader.kt
+++ b/src/main/kotlin/lotto/domain/implementation/LottoReader.kt
@@ -10,9 +10,11 @@ class LottoReader(
     private val lottoBillRepository: LottoBillRepository
 ) {
     @Read
-    fun findBill(billId: Long): LottoBill {
-        return lottoBillRepository
-            .findById(billId)
+    fun findBill(billId: Long, memberId: String): LottoBill =
+        lottoBillRepository.findById(billId)
+            .map { bill ->
+                bill.takeIf { it.isOwner(memberId) }
+                    ?: throw IllegalArgumentException("$memberId is Not Owner")
+            }
             .orElseThrow { IllegalArgumentException("Not Exist Bill") }
-    }
 }

--- a/src/main/kotlin/lotto/domain/implementation/LottoWriter.kt
+++ b/src/main/kotlin/lotto/domain/implementation/LottoWriter.kt
@@ -15,11 +15,12 @@ class LottoWriter(
 
     @Transaction
     @Write
-    fun saveBill(purchase: Purchase, lottoPublish: LottoPublish): LottoBill {
+    fun saveBill(purchase: Purchase, lottoPublish: LottoPublish, memberId: String): LottoBill {
         return lottoBillRepository.save(
             LottoBill(
                 purchase = purchase,
-                lottoPublish = lottoPublish
+                lottoPublish = lottoPublish,
+                memberId = memberId
             )
         )
     }

--- a/src/main/kotlin/lotto/service/LottoPurchaseService.kt
+++ b/src/main/kotlin/lotto/service/LottoPurchaseService.kt
@@ -1,5 +1,6 @@
 package lotto.service
 
+import auth.domain.vo.Authenticated
 import common.business.BusinessService
 import lotto.domain.implementation.LottoPublisher
 import lotto.domain.implementation.LottoReader
@@ -21,18 +22,20 @@ class LottoPurchaseService(
 ) {
     fun purchase(
         lottoPurchaseRequest: LottoPurchaseRequest,
-        lottoPublishId: Long
+        lottoPublishId: Long,
+        authenticated: Authenticated
     ): LottoPurchaseData {
         orderValidator.checkOrderValid(lottoPurchaseRequest.toOrderDataRequest())
         val lottoPublish = lottoPublisher.findPublish(lottoPublishId)
         val purchase = purchaseProcessor.purchase(lottoPurchaseRequest.toPurchaseRequest())
-        return LottoPurchaseData.from(lottoWriter.saveBill(purchase, lottoPublish))
+        return LottoPurchaseData.from(lottoWriter.saveBill(purchase, lottoPublish,authenticated.memberId))
     }
 
     fun cancel(
-        billId: Long
+        billId: Long,
+        authenticated: Authenticated
     ): LottoPurchaseData {
-        val bill = lottoReader.findBill(billId)
+        val bill = lottoReader.findBill(billId,authenticated.memberId)
         val purchase = purchaseProcessor.cancel(bill.getPurchase())
         val lottoPublish = lottoPublisher.unPublish(bill.getLottoPublish())
         return LottoPurchaseData(

--- a/src/main/kotlin/member/controller/InfoHttpResponse.kt
+++ b/src/main/kotlin/member/controller/InfoHttpResponse.kt
@@ -1,8 +1,0 @@
-package member.controller
-
-import java.util.*
-
-data class InfoHttpResponse(
-    val id: UUID,
-    val email: String
-)

--- a/src/main/kotlin/member/controller/LocalRegisterHttpResponse.kt
+++ b/src/main/kotlin/member/controller/LocalRegisterHttpResponse.kt
@@ -1,8 +1,6 @@
 package member.controller
 
-import java.util.UUID
-
 class LocalRegisterHttpResponse(
-    val id:UUID,
+    val id: String,
 ) {
 }

--- a/src/main/kotlin/member/controller/MemberController.kt
+++ b/src/main/kotlin/member/controller/MemberController.kt
@@ -35,11 +35,11 @@ class MemberController(
     }
 
     @Get("/api/auth")
-    fun info(accessToken: AccessToken): ApiResponse<InfoHttpResponse> {
+    fun info(accessToken: AccessToken): ApiResponse<MemberInfoHttpResponse> {
         val memberId = tokenService.decodeToken(accessToken)
         val memberData = memberService.readMember(memberId)
         return apiResponse {
-            data = InfoHttpResponse(
+            data = MemberInfoHttpResponse(
                 id = memberData.id,
                 email = memberData.email
             )

--- a/src/main/kotlin/member/controller/MemberInfoHttpResponse.kt
+++ b/src/main/kotlin/member/controller/MemberInfoHttpResponse.kt
@@ -1,0 +1,6 @@
+package member.controller
+
+data class MemberInfoHttpResponse(
+    val id: String,
+    val email: String
+)

--- a/src/main/kotlin/member/service/dto/MemberData.kt
+++ b/src/main/kotlin/member/service/dto/MemberData.kt
@@ -4,14 +4,14 @@ import member.domain.entity.Member
 import java.util.*
 
 data class MemberData(
-    val id: UUID,
+    val id: String,
     val email: String,
     val password: String
 ) {
     companion object {
         fun from(member: Member): MemberData {
             return MemberData(
-                id = member.getId(),
+                id = member.getId().toString(),
                 email = member.getEmail(),
                 password = member.getPassword()
             )

--- a/src/test/kotlin/TestConstant.kt
+++ b/src/test/kotlin/TestConstant.kt
@@ -10,14 +10,5 @@ object TestConstant {
     const val EXPIRED_TOKEN =
         "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkZmMzYWQ4Mi1lM2JhLTQ1MjAtYTk2OS0wYjRhMjkzYzlhOGIiLCJpYXQiOjE3Mzg4NTMxMDksImV4cCI6MTczODg1MzEwOX0.I3ej_tEDUKtDpp7C2DowJGI6EI_F3RIRPhmwUhRYMmU"
 
-    val DATE_TIME = LocalDateTime.now()
-
-    val ONGOING_LOTTO_ROUND = LottoRoundInfo(
-        null,
-        round = 1,
-        startDate = DATE_TIME.minusHours(1),
-        endDate = DATE_TIME.plusHours(1),
-        drawDate = DATE_TIME.plusHours(2),
-        paymentDeadline = DATE_TIME.plusYears(1),
-    )
+    val DATE_TIME: LocalDateTime = LocalDateTime.now()
 }

--- a/src/test/kotlin/TestConstant.kt
+++ b/src/test/kotlin/TestConstant.kt
@@ -1,0 +1,23 @@
+import lotto.domain.entity.LottoRoundInfo
+import java.time.LocalDateTime
+
+object TestConstant {
+    // 의도적으로 시간을 매우 늘려서 사용자의 토큰을 받아놓았다.(expire : 16000000000000000)
+    const val TOKEN =
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkZmMzYWQ4Mi1lM2JhLTQ1MjAtYTk2OS0wYjRhMjkzYzlhOGIiLCJpYXQiOjE3Mzg4NTIyMzIsImV4cCI6MTYwMDE3Mzg4NTIyMzJ9.bzacSBSyi3gakhKau6-m2fZTY-VllRzq0m5Crf0-ZGs"
+
+    // 의도적으로 시간을 매우 짧게 사용자의 토큰을 받아놓았다.(expire: 10)
+    const val EXPIRED_TOKEN =
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkZmMzYWQ4Mi1lM2JhLTQ1MjAtYTk2OS0wYjRhMjkzYzlhOGIiLCJpYXQiOjE3Mzg4NTMxMDksImV4cCI6MTczODg1MzEwOX0.I3ej_tEDUKtDpp7C2DowJGI6EI_F3RIRPhmwUhRYMmU"
+
+    val DATE_TIME = LocalDateTime.now()
+
+    val ONGOING_LOTTO_ROUND = LottoRoundInfo(
+        null,
+        round = 1,
+        startDate = DATE_TIME.minusHours(1),
+        endDate = DATE_TIME.plusHours(1),
+        drawDate = DATE_TIME.plusHours(2),
+        paymentDeadline = DATE_TIME.plusYears(1),
+    )
+}

--- a/src/test/kotlin/lotto/Fixture.kt
+++ b/src/test/kotlin/lotto/Fixture.kt
@@ -1,5 +1,6 @@
 package lotto
 
+import TestConstant
 import lotto.domain.entity.LottoRoundInfo
 import lotto.domain.entity.LottoStatus
 import java.time.LocalDateTime
@@ -24,4 +25,19 @@ class Fixture {
             )
         }
     }
+
+    object LottoRoundFixture {
+        fun createOngoingLottoRoundInfo(dateTime: LocalDateTime = TestConstant.DATE_TIME): LottoRoundInfo {
+            return LottoRoundInfo(
+                id = null,
+                round = 1,
+                startDate = dateTime.minusHours(1),
+                endDate = dateTime.plusHours(1),
+                drawDate = dateTime.plusHours(2),
+                paymentDeadline = dateTime.plusYears(1)
+            )
+        }
+    }
+
+
 }

--- a/src/test/kotlin/lotto/controller/LottoPurchaseCancelTest.kt
+++ b/src/test/kotlin/lotto/controller/LottoPurchaseCancelTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 class LottoPurchaseCancelTest {
     @Test
     fun `인증된 사용자가 아니면 결제 취소를 실패 한다`() {
-        DocsApiBuilder("cancel-fail-not-authenticated")
+        DocsApiBuilder("cancel-failure-not-authenticated")
             .setRequest("/api/cancel", HttpMethod.POST) {
                 headers {
                     "Authorization" type DocsFieldType.STRING value "Bearer notValidToken"

--- a/src/test/kotlin/lotto/controller/LottoPurchaseCancelTest.kt
+++ b/src/test/kotlin/lotto/controller/LottoPurchaseCancelTest.kt
@@ -1,17 +1,36 @@
 package lotto.controller
 
+import TestConstant
 import config.AcceptanceTest
 import docs.DocsApiBuilder
 import docs.HttpMethod
 import docs.field.DocsFieldType
 import org.junit.jupiter.api.Test
 
-@AcceptanceTest(["/acceptance/lottoCancel.json"])
+@AcceptanceTest(["/acceptance/lottoCancel.json", "acceptance/member.json"])
 class LottoPurchaseCancelTest {
+    @Test
+    fun `인증된 사용자가 아니면 결제 취소를 실패 한다`() {
+        DocsApiBuilder("cancel-fail-not-authenticated")
+            .setRequest("/api/cancel", HttpMethod.POST) {
+                headers {
+                    "Authorization" type DocsFieldType.STRING value "Bearer notValidToken"
+                }
+                body {
+                    "billId" type DocsFieldType.NUMBER means "구매했던 영수증 ID" value 2
+                }
+            }.setResponse {
+            }.execute(true)
+            .statusCode(401)
+    }
+
     @Test
     fun `결제취소를 한다`() {
         DocsApiBuilder("cancel-success")
             .setRequest("/api/cancel", HttpMethod.POST) {
+                headers {
+                    "Authorization" type DocsFieldType.STRING value "Bearer ${TestConstant.TOKEN}"
+                }
                 body {
                     "billId" type DocsFieldType.NUMBER means "구매했던 영수증 ID" value 1
                 }
@@ -29,11 +48,29 @@ class LottoPurchaseCancelTest {
     }
 
     @Test
+    fun `자기가 구매한 요소가 아니면 실패를 한다`() {
+        DocsApiBuilder("cancel-failure-not-owner")
+            .setRequest("/api/cancel", HttpMethod.POST) {
+                headers {
+                    "Authorization" type DocsFieldType.STRING value "Bearer ${TestConstant.TOKEN}"
+                }
+                body {
+                    "billId" type DocsFieldType.NUMBER means "구매했던 영수증 ID" value 2
+                }
+            }
+            .execute()
+            .statusCode(400)
+    }
+
+    @Test
     fun `결제취소 실패를 한다`() {
         DocsApiBuilder("cancel-failure")
             .setRequest("/api/cancel", HttpMethod.POST) {
+                headers {
+                    "Authorization" type DocsFieldType.STRING value "Bearer ${TestConstant.TOKEN}"
+                }
                 body {
-                    "billId" type DocsFieldType.NUMBER means "구매했던 영수증 ID" value 2
+                    "billId" type DocsFieldType.NUMBER means "구매했던 영수증 ID" value 3
                 }
             }
             .execute()

--- a/src/test/kotlin/lotto/domain/implementation/LottoReaderTest.kt
+++ b/src/test/kotlin/lotto/domain/implementation/LottoReaderTest.kt
@@ -2,6 +2,7 @@ package lotto.domain.implementation
 
 import TestConstant
 import config.ImplementationTest
+import lotto.Fixture.LottoRoundFixture.createOngoingLottoRoundInfo
 import lotto.domain.entity.LottoBill
 import lotto.domain.entity.LottoPublish
 import lotto.domain.repository.LottoBillRepository
@@ -47,7 +48,7 @@ class LottoReaderTest {
                 memberId = "memberID",
                 lottoPublish = lottoPublishRepository.save(
                     LottoPublish(
-                        lottoRoundInfo = lottoRoundInfoRepository.save(TestConstant.ONGOING_LOTTO_ROUND),
+                        lottoRoundInfo = lottoRoundInfoRepository.save(createOngoingLottoRoundInfo()),
                         issuedAt = TestConstant.DATE_TIME,
                     )
                 ),

--- a/src/test/kotlin/lotto/domain/implementation/LottoReaderTest.kt
+++ b/src/test/kotlin/lotto/domain/implementation/LottoReaderTest.kt
@@ -1,0 +1,71 @@
+package lotto.domain.implementation
+
+import TestConstant
+import config.ImplementationTest
+import lotto.domain.entity.LottoBill
+import lotto.domain.entity.LottoPublish
+import lotto.domain.repository.LottoBillRepository
+import lotto.domain.repository.LottoPublishRepository
+import lotto.domain.repository.LottoRoundInfoRepository
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import purchase.domain.entity.Purchase
+import purchase.domain.entity.PurchaseInfo
+import purchase.domain.repository.PurchaseRepository
+import purchase.domain.vo.PaymentMethod
+import purchase.domain.vo.PurchaseProvider
+import java.math.BigDecimal
+import kotlin.test.Test
+
+@ImplementationTest
+class LottoReaderTest {
+
+    @Autowired
+    private lateinit var lottoBillRepository: LottoBillRepository
+
+    @Autowired
+    private lateinit var lottoPublishRepository: LottoPublishRepository
+
+    @Autowired
+    private lateinit var lottoRoundInfoRepository: LottoRoundInfoRepository
+
+    @Autowired
+    private lateinit var purchaseRepository: PurchaseRepository
+
+    @Autowired
+    private lateinit var lottoReader: LottoReader
+
+    /**
+     *
+     * 해당 부분은 사실, 예외를 던지는게 아닌 다른 VO 를 만들어서 ( owned,notOwned 와 같이 flag 를 만들어 주는게 타당한 거 같다. )
+     * Reader 가 이를 판단해 예외를 던지는게 이상하다고 생각하기 때문
+     */
+    @Test
+    fun `영수증의 멤버 ID가 일치하지 않으면 예외를 발생한다`() {
+        val bill = lottoBillRepository.save(
+            LottoBill(
+                memberId = "memberID",
+                lottoPublish = lottoPublishRepository.save(
+                    LottoPublish(
+                        lottoRoundInfo = lottoRoundInfoRepository.save(TestConstant.ONGOING_LOTTO_ROUND),
+                        issuedAt = TestConstant.DATE_TIME,
+                    )
+                ),
+                purchase = purchaseRepository.save(
+                    Purchase(
+                        paymentKey = "paymentKey",
+                        orderId = "orderId",
+                        status = "SUCCESS",
+                        purchaseProvider = PurchaseProvider.TOSS,
+                        purchaseInfo = PurchaseInfo(totalAmount = BigDecimal(1000), method = PaymentMethod.CARD)
+                    )
+                ),
+            )
+        )
+        assertThrows<IllegalArgumentException> {
+            lottoReader.findBill(
+                bill.getId()!!,"notExist"
+            )
+        }
+    }
+}

--- a/src/test/kotlin/lotto/service/LottoPurchaseServiceCancelTest.kt
+++ b/src/test/kotlin/lotto/service/LottoPurchaseServiceCancelTest.kt
@@ -1,0 +1,77 @@
+package lotto.service
+
+import app.TestConfig
+import auth.domain.vo.AuthenticatedMember
+import config.ImplementationTest
+import lotto.Fixture.LottoRoundFixture.createOngoingLottoRoundInfo
+import lotto.domain.entity.LottoBill
+import lotto.domain.entity.LottoPublish
+import lotto.domain.repository.LottoBillRepository
+import lotto.domain.repository.LottoPublishRepository
+import lotto.domain.repository.LottoRoundInfoRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+import purchase.domain.entity.Purchase
+import purchase.domain.entity.PurchaseInfo
+import purchase.domain.repository.PurchaseRepository
+import purchase.domain.vo.PaymentMethod
+import purchase.domain.vo.PurchaseProvider
+import java.math.BigDecimal
+
+@ImplementationTest
+@Import(TestConfig::class)
+class LottoPurchaseServiceCancelTest {
+    private lateinit var bill: LottoBill
+
+    @Autowired
+    private lateinit var lottoPublishRepository: LottoPublishRepository
+
+    @Autowired
+    private lateinit var purchaseRepository: PurchaseRepository
+
+    @Autowired
+    private lateinit var lottoBillRepository: LottoBillRepository
+
+    @Autowired
+    private lateinit var lottoPurchaseService: LottoPurchaseService
+
+    @Autowired
+    private lateinit var lottoRoundInfoRepository: LottoRoundInfoRepository
+
+    @BeforeEach
+    fun setup() {
+        val publish = lottoPublishRepository.save(
+            LottoPublish(
+                lottoRoundInfo = lottoRoundInfoRepository.save(
+                    createOngoingLottoRoundInfo()
+                ),
+                issuedAt = TestConstant.DATE_TIME,
+            )
+        )
+        val purchase = purchaseRepository.save(
+            Purchase(
+                paymentKey = "paymentKey",
+                orderId = "orderId",
+                status = "SUCCESS",
+                purchaseProvider = PurchaseProvider.TOSS,
+                purchaseInfo = PurchaseInfo(totalAmount = BigDecimal(1000), method = PaymentMethod.CARD)
+            )
+        )
+        bill = lottoBillRepository.save(
+            LottoBill(lottoPublish = publish, purchase = purchase, memberId = "ID")
+        )
+    }
+
+    @Test
+    fun `취소가 성공적으로 진행된다`() {
+        assertDoesNotThrow {
+            lottoPurchaseService.cancel(
+                billId = bill.getId()!!,
+                authenticated = AuthenticatedMember("ID", "user@email.com")
+            )
+        }
+    }
+}

--- a/src/test/kotlin/lotto/service/LottoPurchaseServiceConfirmTest.kt
+++ b/src/test/kotlin/lotto/service/LottoPurchaseServiceConfirmTest.kt
@@ -4,9 +4,8 @@ import TestConstant
 import app.TestConfig
 import auth.domain.vo.AuthenticatedMember
 import config.ImplementationTest
-import lotto.domain.entity.LottoBill
+import lotto.Fixture.LottoRoundFixture.createOngoingLottoRoundInfo
 import lotto.domain.entity.LottoPublish
-import lotto.domain.repository.LottoBillRepository
 import lotto.domain.repository.LottoPublishRepository
 import lotto.domain.repository.LottoRoundInfoRepository
 import lotto.domain.vo.Currency
@@ -20,17 +19,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
-import purchase.domain.entity.Purchase
-import purchase.domain.entity.PurchaseInfo
-import purchase.domain.repository.PurchaseRepository
-import purchase.domain.vo.PaymentMethod
-import purchase.domain.vo.PurchaseProvider
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
 @ImplementationTest
 @Import(TestConfig::class)
-class LottoPurchaseServiceTest {
+class LottoPurchaseServiceConfirmTest {
 
     @Autowired
     private lateinit var lottoPurchaseService: LottoPurchaseService
@@ -41,6 +35,9 @@ class LottoPurchaseServiceTest {
     @Autowired
     private lateinit var orderRepository: OrderRepository
 
+    @Autowired
+    private lateinit var lottoPublishRepository: LottoPublishRepository
+
     private var lottoPublishId: Long = 0
 
     @Nested
@@ -48,7 +45,7 @@ class LottoPurchaseServiceTest {
         @BeforeEach
         fun setUp() {
             val roundInfo = lottoRoundInfoRepository.save(
-                TestConstant.ONGOING_LOTTO_ROUND
+                createOngoingLottoRoundInfo()
             )
             orderRepository.save(
                 Order(
@@ -76,54 +73,6 @@ class LottoPurchaseServiceTest {
                         orderId = "orderId"
                     ),
                     lottoPublishId = lottoPublishId,
-                    authenticated = AuthenticatedMember("ID", "user@email.com")
-                )
-            }
-        }
-    }
-
-    @Autowired
-    private lateinit var lottoPublishRepository: LottoPublishRepository
-
-    @Autowired
-    private lateinit var purchaseRepository: PurchaseRepository
-
-    @Autowired
-    private lateinit var lottoBillRepository: LottoBillRepository
-
-    @Nested
-    inner class CancelCase {
-        private lateinit var bill: LottoBill
-
-        @BeforeEach
-        fun setup() {
-            val publish = lottoPublishRepository.save(
-                LottoPublish(
-                    lottoRoundInfo = lottoRoundInfoRepository.save(
-                        TestConstant.ONGOING_LOTTO_ROUND
-                    ),
-                    issuedAt = TestConstant.DATE_TIME,
-                )
-            )
-            val purchase = purchaseRepository.save(
-                Purchase(
-                    paymentKey = "paymentKey",
-                    orderId = "orderId",
-                    status = "SUCCESS",
-                    purchaseProvider = PurchaseProvider.TOSS,
-                    purchaseInfo = PurchaseInfo(totalAmount = BigDecimal(1000), method = PaymentMethod.CARD)
-                )
-            )
-            bill = lottoBillRepository.save(
-                LottoBill(lottoPublish = publish, purchase = purchase, memberId = "ID")
-            )
-        }
-
-        @Test
-        fun `취소가 성공적으로 진행된다`() {
-            assertDoesNotThrow {
-                lottoPurchaseService.cancel(
-                    billId = bill.getId()!!,
                     authenticated = AuthenticatedMember("ID", "user@email.com")
                 )
             }

--- a/src/test/kotlin/member/controller/MemberInfoTest.kt
+++ b/src/test/kotlin/member/controller/MemberInfoTest.kt
@@ -1,5 +1,6 @@
 package member.controller
 
+import TestConstant
 import config.AcceptanceTest
 import docs.DocsApiBuilder
 import docs.HttpMethod
@@ -8,20 +9,12 @@ import org.junit.jupiter.api.Test
 
 @AcceptanceTest(["/acceptance/member.json"])
 class MemberInfoTest {
-    // 의도적으로 시간을 매우 늘려서 사용자의 토큰을 받아놓았다.(expire : 16000000000000000)
-    private val token =
-        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkZmMzYWQ4Mi1lM2JhLTQ1MjAtYTk2OS0wYjRhMjkzYzlhOGIiLCJpYXQiOjE3Mzg4NTIyMzIsImV4cCI6MTYwMDE3Mzg4NTIyMzJ9.bzacSBSyi3gakhKau6-m2fZTY-VllRzq0m5Crf0-ZGs"
-
-    // 의도적으로 시간을 매우 짧게 사용자의 토큰을 받아놓았다.(expire: 10)
-    private val expiredToken =
-        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkZmMzYWQ4Mi1lM2JhLTQ1MjAtYTk2OS0wYjRhMjkzYzlhOGIiLCJpYXQiOjE3Mzg4NTMxMDksImV4cCI6MTczODg1MzEwOX0.I3ej_tEDUKtDpp7C2DowJGI6EI_F3RIRPhmwUhRYMmU"
-
     @Test
     fun `토큰을 통해 사용자의 정보를 받는다`() {
         DocsApiBuilder("info-success")
             .setRequest("/api/auth", HttpMethod.GET) {
                 headers {
-                    "Authorization" type DocsFieldType.STRING means "인증 토큰" value "Bearer $token"
+                    "Authorization" type DocsFieldType.STRING means "인증 토큰" value "Bearer ${TestConstant.TOKEN}"
                 }
             }
             .setResponse {
@@ -53,7 +46,7 @@ class MemberInfoTest {
         DocsApiBuilder("info-fail-not-valid-token")
             .setRequest("/api/auth", HttpMethod.GET) {
                 headers {
-                    "Authorization" type DocsFieldType.STRING means "인증 토큰" value "Bearer $expiredToken"
+                    "Authorization" type DocsFieldType.STRING means "인증 토큰" value "Bearer ${TestConstant.EXPIRED_TOKEN}"
                 }
             }
             .setResponse {

--- a/src/test/resources/acceptance/lottoCancel.json
+++ b/src/test/resources/acceptance/lottoCancel.json
@@ -18,11 +18,24 @@
       "purchase_info_id": "b4386e47-8555-437c-bcd9-164262a9a3bd",
       "purchase_provider": "TOSS",
       "status": "SUCCESS"
+    },
+    {
+      "id": "dfb3ad82-ab2d-4220-a969-0b4a293c9a8b",
+      "order_id": "orderId2",
+      "payment_key": "duplicatePaymentKey2",
+      "purchase_info_id": "b4386e47-8555-437c-bcd9-164262a9a3be",
+      "purchase_provider": "TOSS",
+      "status": "SUCCESS"
     }
   ],
   "purchase_info": [
     {
       "id":"b4386e47-8555-437c-bcd9-164262a9a3bd",
+      "total_amount":1000,
+      "method": "CARD"
+    },
+    {
+      "id":"b4386e47-8555-437c-bcd9-164262a9a3be",
       "total_amount":1000,
       "method": "CARD"
     }
@@ -33,13 +46,26 @@
       "lotto_round_info_id": 1,
       "issued_at": "now()",
       "canceled": false
+    },
+    {
+      "id": 2,
+      "lotto_round_info_id": 1,
+      "issued_at": "now()",
+      "canceled": false
     }
   ],
   "lotto_bill": [
     {
       "id": 1,
       "purchase_id": "dfb3ad82-e2ba-4220-a969-0b4a293c9a8b",
-      "lotto_publish_id": 1
+      "lotto_publish_id": 1,
+      "member_id": "dfc3ad82-e3ba-4520-a969-0b4a293c9a8b"
+    },
+    {
+      "id": 2,
+      "purchase_id": "dfb3ad82-ab2d-4220-a969-0b4a293c9a8b",
+      "lotto_publish_id": 2,
+      "member_id": "dfc3ad82-e3ba-4520-a969-123b4qcdb8db"
     }
   ],
   "orders": [


### PR DESCRIPTION
결제 취소와 승인 API 를 사용자의 토큰을 받은 후에만 사용 가능하게 추가했습니다.


`결제 승인할때, 사용자의 로그인이 진짜로 필요한가?( 결제 했는데, 로그인을 못해서 거절당하는게 맞는가? )`

를 고민했으나
- 결제 로직상 승인까지 시간을 20분 가량 넉넉하게 주는 점
- 결제 승인은 `번호 선택 - 결제 SDK 통한 결제 - 승인` 오래 걸리지 않는 점

을 통해 인증을 받은채로 처리했습니다.

다음은, `인증 통한 로또 조회`, `외부 결제 API Limit 제한` 을 구현할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **문서 업데이트**
	- 로또 결제 실패 및 취소 관련 API 문서에 인증 실패, 영수증 미존재 등의 상세 실패 케이스와 성공 응답에 관한 새로운 안내 섹션이 추가되었습니다.
- **새로운 기능**
	- 로또 구매 및 취소 요청 시 인증된 사용자 정보가 반드시 포함되어 보안과 권한 검증이 강화되었습니다.
	- 회원 정보 응답 형식이 업데이트되어 데이터 전달이 일관되고 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->